### PR TITLE
Add option to filter entries by tag in tinyMCE tplist dialog

### DIFF
--- a/core/general.php
+++ b/core/general.php
@@ -413,6 +413,14 @@ function tp_write_data_for_tinymce () {
         }
     }
     
+    // List of publication tags
+    $pub_tag_list = array();
+    $pub_tag_list[] = array( 'text' => 'All', 'value' => null );
+    $pub_tags = tp_tags::get_tags(array( 'group_by' => true ));
+    foreach($pub_tags as $pub_tag){
+		$pub_tag_list[] = array( 'text' => $pub_tag->name, 'value' => intval($pub_tag->tag_id) );
+    }
+    
     // List of publication templates
     $pub_templates_list = array();
     $pub_templates = tp_list_templates();
@@ -429,6 +437,7 @@ function tp_write_data_for_tinymce () {
         var teachpress_courses = <?php echo json_encode($course_list); ?>;
         var teachpress_semester = <?php echo json_encode($semester_list); ?>;
         var teachpress_pub_user = <?php echo json_encode($pub_user_list); ?>;
+        var teachpress_pub_tags = <?php echo json_encode($pub_tag_list) ?>;
         var teachpress_pub_templates = <?php echo json_encode($pub_templates_list); ?>;
         var teachpress_editor_url = '<?php echo plugins_url() . '/teachpress/admin/document-manager.php?post_id=' . $post_id; ?>';
         var teachpress_cookie_path = '<?php echo SITECOOKIEPATH; ?>';

--- a/js/tinymce-plugin.js
+++ b/js/tinymce-plugin.js
@@ -394,7 +394,14 @@
                                                     name: 'tp_entries_per_page',
                                                     label: 'Entries per page',
                                                     value: '50'
-                                                }
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_filter_tag',
+                                                    label: 'Only entries with tag',
+                                                    value: null,
+                                                    values: teachpress_pub_tags
+                                                },
                                             ]
                                         },
                                         {
@@ -488,7 +495,7 @@
                                         
                                         var user = filterData.tp_user;
                                         var entries_per_page = filterData.tp_entries_per_page;
-                                        
+                                        var tag = filterData.tp_filter_tag;                                        
                                         var headline = designData.tp_headline;
                                         var image = designData.tp_image;
                                         var image_size = designData.tp_size;
@@ -499,6 +506,8 @@
                                         var link_style = designData.tp_link_style;
                                         
                                         user = (user === '') ? '' : 'user="' + user + '"';
+                                        entries_per_page = (entries_per_page === '50') ? '' : 'entries_per_page="' + entries_per_page + '"';
+                                        tag = (tag == null) ? '' : 'tag="' + tag + '"';                                        
                                         headline = (headline === '1') ? '' : 'headline="' + headline + '"';
                                         image = (image === 'none') ? '' : 'image="' + image + '"';
                                         image_size = (image_size === '0') ? '' : 'image_size="' + image_size + '"';
@@ -507,9 +516,8 @@
                                         editor_name = (editor_name === 'last') ? '' : 'editor_name="' + editor_name + '"';
                                         style = (style === 'none') ? '' : 'style="' + style + '"';
                                         link_style = (link_style === 'inline') ? '' : 'link_style="' + link_style + '"';
-                                        entries_per_page = (entries_per_page === '50') ? '' : 'entries_per_page="' + entries_per_page + '"';
                                         
-                                        editor.insertContent( '[tplist ' + user + ' ' + headline + ' ' + image + ' ' + image_size + ' ' + author_name + ' ' + editor_name + ' ' + style + ' ' + template + ' ' + link_style + ' ' + entries_per_page + ']');
+                                        editor.insertContent( '[tplist ' + user + ' ' + entries_per_page + ' ' + tag + ' ' + headline + ' ' + image + ' ' + image_size + ' ' + author_name + ' ' + editor_name + ' ' + style + ' ' + template + ' ' + link_style + ']');
                                     }
                                 });
                             }

--- a/js/tinymce-plugin.js
+++ b/js/tinymce-plugin.js
@@ -373,110 +373,130 @@
                         {
                             text: 'Publication list [tplist]',
                             onclick: function() {
+                                var data = {};
                                 editor.windowManager.open( {
                                     title: 'Insert publication list [tplist]',
+                                    bodyType: 'tabpanel',
                                     body: [
                                         {
-                                            type: 'listbox',
-                                            name: 'tp_user',
-                                            label: 'Select user',
-                                            'values': teachpress_pub_user //  is written by tp_write_data_for_tinymce()
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_headline',
-                                            label: 'Headline',
-                                            'values': [
-                                                {text: 'years', value: '1'},
-                                                {text: 'publication types', value: '2'},
-                                                {text: 'headlines grouped by year then by type', value: '3'},
-                                                {text: 'headlines grouped by type then by year', value: '4'},
-                                                {text: 'none', value: '0'}
+                                            title: 'Filter',
+                                            type: 'form',
+                                            name: 'tp_filterform',
+                                            items: [
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_user',
+                                                    label: 'Select user',
+                                                    'values': teachpress_pub_user //  is written by tp_write_data_for_tinymce()
+                                                },
+                                                {
+                                                    type: 'textbox',
+                                                    name: 'tp_entries_per_page',
+                                                    label: 'Entries per page',
+                                                    value: '50'
+                                                }
                                             ]
                                         },
                                         {
-                                            type: 'listbox',
-                                            name: 'tp_image',
-                                            label: 'Show images',
-                                            'values': [
-                                                {text: 'none', value: 'none'},
-                                                {text: 'left', value: 'left'},
-                                                {text: 'right', value: 'right'},
-                                                {text: 'bottom', value: 'bottom'}
+                                            title: 'Design',
+                                            type: 'form',
+                                            name: 'tp_designform',
+                                            items: [
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_headline',
+                                                    label: 'Headline',
+                                                    'values': [
+                                                        {text: 'years', value: '1'},
+                                                        {text: 'publication types', value: '2'},
+                                                        {text: 'headlines grouped by year then by type', value: '3'},
+                                                        {text: 'headlines grouped by type then by year', value: '4'},
+                                                        {text: 'none', value: '0'}
+                                                    ]
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_image',
+                                                    label: 'Show images',
+                                                    'values': [
+                                                        {text: 'none', value: 'none'},
+                                                        {text: 'left', value: 'left'},
+                                                        {text: 'right', value: 'right'},
+                                                        {text: 'bottom', value: 'bottom'}
+                                                    ]
+                                                },
+                                                {
+                                                    type: 'textbox',
+                                                    name: 'tp_size',
+                                                    label: 'Image size in px',
+                                                    value: '0'
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_author_name',
+                                                    label: 'Style of the author names',
+                                                    'values': [
+                                                        {text: 'last (example: van der Vaart, Ludwig)', value: 'last'},
+                                                        {text: 'initials (example: van der Vaart, Ludwig C)', value: 'initials'},
+                                                        {text: 'simple (example: Ludwig C. van der Vaart)', value: 'simple'},
+                                                        {text: 'old (example: Vaart, Ludwig C. van der)', value: 'old'}
+                                                    ]
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_editor_name',
+                                                    label: 'Style of the editor names',
+                                                    'values': [
+                                                        {text: 'last (example: van der Vaart, Ludwig)', value: 'last'},
+                                                        {text: 'initials (example: van der Vaart, Ludwig C)', value: 'initials'},
+                                                        {text: 'simple (example: Ludwig C. van der Vaart)', value: 'simple'},
+                                                        {text: 'old (example: Vaart, Ludwig C. van der)', value: 'old'}
+                                                    ]
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_style',
+                                                    label: 'Numeration of publication lists',
+                                                    'values': [
+                                                        {text: 'none', value: 'none'},
+                                                        {text: 'numbered', value: 'numbered'},
+                                                        {text: 'numbered descending', value: 'numbered_desc'}
+                                                    ]
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_template',
+                                                    label: 'Template',
+                                                    'values': teachpress_pub_templates  //  is written by tp_write_data_for_tinymce()
+                                                },
+                                                {
+                                                    type: 'listbox',
+                                                    name: 'tp_link_style',
+                                                    label: 'Style of publication links',
+                                                    'values': [
+                                                        {text: 'inline', value: 'inline'},
+                                                        {text: 'images', value: 'images'},
+                                                        {text: 'direct', value: 'direct'}
+                                                    ]
+                                                }
                                             ]
-                                        },
-                                        {
-                                            type: 'textbox',
-                                            name: 'tp_size',
-                                            label: 'Image size in px',
-                                            value: '0'
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_author_name',
-                                            label: 'Style of the author names',
-                                            'values': [
-                                                {text: 'last (example: van der Vaart, Ludwig)', value: 'last'},
-                                                {text: 'initials (example: van der Vaart, Ludwig C)', value: 'initials'},
-                                                {text: 'simple (example: Ludwig C. van der Vaart)', value: 'simple'},
-                                                {text: 'old (example: Vaart, Ludwig C. van der)', value: 'old'}
-                                            ]
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_editor_name',
-                                            label: 'Style of the editor names',
-                                            'values': [
-                                                {text: 'last (example: van der Vaart, Ludwig)', value: 'last'},
-                                                {text: 'initials (example: van der Vaart, Ludwig C)', value: 'initials'},
-                                                {text: 'simple (example: Ludwig C. van der Vaart)', value: 'simple'},
-                                                {text: 'old (example: Vaart, Ludwig C. van der)', value: 'old'}
-                                            ]
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_style',
-                                            label: 'Numeration of publication lists',
-                                            'values': [
-                                                {text: 'none', value: 'none'},
-                                                {text: 'numbered', value: 'numbered'},
-                                                {text: 'numbered descending', value: 'numbered_desc'}
-                                            ]
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_template',
-                                            label: 'Template',
-                                            'values': teachpress_pub_templates  //  is written by tp_write_data_for_tinymce()
-                                        },
-                                        {
-                                            type: 'listbox',
-                                            name: 'tp_link_style',
-                                            label: 'Style of publication links',
-                                            'values': [
-                                                {text: 'inline', value: 'inline'},
-                                                {text: 'images', value: 'images'},
-                                                {text: 'direct', value: 'direct'}
-                                            ]
-                                        },
-                                        {
-                                            type: 'textbox',
-                                            name: 'tp_entries_per_page',
-                                            label: 'Entries per page',
-                                            value: '50'
                                         }
                                     ],
                                     onsubmit: function( e ) {
-                                        var user = e.data.tp_user;
-                                        var headline = e.data.tp_headline;
-                                        var image = e.data.tp_image;
-                                        var image_size = e.data.tp_size;
-                                        var template = e.data.tp_template;
-                                        var author_name = e.data.tp_author_name;
-                                        var editor_name = e.data.tp_editor_name;
-                                        var style = e.data.tp_style;
-                                        var link_style = e.data.tp_link_style;
-                                        var entries_per_page = e.data.tp_entries_per_page;
+                                        var filterData = this.find('[name=tp_filterform]')[0].toJSON();
+                                        var designData = this.find('[name=tp_designform]')[0].toJSON();
+                                        
+                                        var user = filterData.tp_user;
+                                        var entries_per_page = filterData.tp_entries_per_page;
+                                        
+                                        var headline = designData.tp_headline;
+                                        var image = designData.tp_image;
+                                        var image_size = designData.tp_size;
+                                        var template = designData.tp_template;
+                                        var author_name = designData.tp_author_name;
+                                        var editor_name = designData.tp_editor_name;
+                                        var style = designData.tp_style;
+                                        var link_style = designData.tp_link_style;
                                         
                                         user = (user === '') ? '' : 'user="' + user + '"';
                                         headline = (headline === '1') ? '' : 'headline="' + headline + '"';


### PR DESCRIPTION
Added a tinyMCE ListBox containing all existing tags that adds the "tag" property to the generated shortcode.
I split up the dialog because I planned to allow the selection of multiple tags, which however seems to be impossible with the current tinyMCE controls. (see: [tinyMCE Issue #2239](https://github.com/tinymce/tinymce/issues/2239))