### PR TITLE
Remove annoying extra space in bibliographic template

### DIFF
--- a/templates/tp_template_orig_s.php
+++ b/templates/tp_template_orig_s.php
@@ -68,7 +68,7 @@ class tp_template_orig_s implements tp_publication_template {
         $s .= '<td class="tp_pub_info_simple">';
         $s .= $interface->get_author('<span class="tp_pub_author_simple">', '</span>');
         $s .= '<span class="tp_pub_year_simple"> (' . $interface->get_year() . ')</span>: ';
-        $s .= '<span class="tp_pub_title_simple">' . $interface->get_title() . ' </span>. ';
+        $s .= '<span class="tp_pub_title_simple">' . $interface->get_title() . '</span>. ';
         $s .= '<span class="tp_pub_additional_simple">' . $interface->get_meta() . '</span> ';
         $s .= '<span class="tp_pub_tags_simple">(' . __('Type','teachpress') . ': ' . $interface->get_type() . ' | ' . $interface->get_tag_line() . ')</span>';
         $s .= $interface->get_infocontainer();


### PR DESCRIPTION
This gets rid of a long-standing extra space in the default template.