### PR TITLE
Allows to define a custom doi resolver

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -418,6 +418,17 @@ class tp_settings_page {
         echo '<th width="160">' . __('Overwrite publications','teachpress') . '</th>';
         echo '<td>' . tp_admin::get_checkbox('import_overwrite', __('Allow optional overwriting for publication import','teachpress'), get_tp_option('import_overwrite')) . ' <b>(EXPERIMENTAL)</b></td>';
         echo '</tr>';
+		
+		echo '<tr>';
+        echo '<th colspan="2"><h3>' . __('DOI Resolver','teachpress') . '</h3></th>';
+        echo '</tr>';
+		
+		echo '<tr>';
+        echo '<th>' . __('Custom Url Template','teachpress') . '</th>';
+        echo '<td><input type="text" name="doi_resolver_url_template_custom" id="doi_resolver_url_template_custom" style="width:90%;" value="' . get_tp_option('doi_resolver_url_template_custom') . '" />';
+		echo '<p>' . __('Define a custom doi resolver template which overrides the default one: ','teachpress') . '<code>' . get_tp_option('doi_resolver_url_template_default') . '</code></p>';
+		echo '</td>';
+		echo '</tr>';
         
         echo '<tr>';
         echo '<th colspan="2"><h3>' . __('Related content','teachpress') . '</h3></th>';
@@ -825,9 +836,11 @@ class tp_settings_page {
     private static function change_publication_options () {
         $checkbox_convert_bibtex = isset( $_POST['convert_bibtex'] ) ? 1 : '';
         $checkbox_import_overwrite = isset( $_POST['import_overwrite'] ) ? 1 : '';
+		$doi_resolver_url_template_custom = isset( $_POST['doi_resolver_url_template_custom'] ) ? esc_url_raw( $_POST['doi_resolver_url_template_custom'] ) : '';
         $checkbox_rel_content_auto = isset( $_POST['rel_content_auto'] ) ? 1 : '';
         tp_options::change_option('convert_bibtex', $checkbox_convert_bibtex, 'checkbox');
         tp_options::change_option('import_overwrite', $checkbox_import_overwrite, 'checkbox');
+		tp_options::change_option('doi_resolver_url_template_custom', $doi_resolver_url_template_custom);
         tp_options::change_option('rel_content_auto', $checkbox_rel_content_auto, 'checkbox');
         tp_options::change_option('rel_content_template', $_POST['rel_content_template']);
         tp_options::change_option('rel_content_category', $_POST['rel_content_category']);

--- a/core/class-tables.php
+++ b/core/class-tables.php
@@ -429,6 +429,8 @@ class tp_tables {
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('rel_content_category', '', 'system')");
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('import_overwrite', '0', 'system')");
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('convert_bibtex', '0', 'system')");
+		$wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('doi_resolver_url_template_default', 'https://dx.doi.org/%doi%', 'system')");
+		$wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('doi_resolver_url_template_custom', '', 'system')");
         // Example values
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('Example term', 'Example term', 'semester')");
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('Example', 'Example', 'course_of_studies')");	

--- a/core/templates.php
+++ b/core/templates.php
@@ -424,8 +424,8 @@ class tp_html_publication_template {
         
         // for direct style (if a DOI numer exists)
         elseif ( $row['doi'] != '' && $settings['link_style'] === 'direct' ) {
-            $doi_url = 'http://dx.doi.org/' . $row['doi'];
-            $title = tp_html::prepare_title($row['title'], 'decode');
+			$title = tp_html::prepare_title($row['title'], 'decode');
+			$doi_url = tp_html_publication_template::prepare_doi_url($row['doi']);
             return '<a class="tp_title_link" href="' . $doi_url . '" title="' . $title . '" target="blank">' . $title . '</a>'; 
         }
         
@@ -498,14 +498,16 @@ class tp_html_publication_template {
          * Add DOI-URL
          * @since 5.0.0
          */
-        if ( $doi != '' ) {
-            $doi_url = 'http://dx.doi.org/' . $doi;
-            if ( $mode === 'list' ) {
-                $end .= '<li><a class="tp_pub_list" style="background-image: url(' . get_tp_mimetype_images( 'html' ) . ')" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank">doi:' . $doi . '</a></li>';
-            }
-            else {
-                $end .= '<a class="tp_pub_link" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank"><img class="tp_pub_link_image" alt="" src="' . get_tp_mimetype_images( 'html' ) . '"/></a>';
-            }
+		if ($doi != '') {
+			
+			$doi_url = tp_html_publication_template::prepare_doi_url($doi);
+			
+			if ( $mode === 'list' ) {
+				$end .= '<li><a class="tp_pub_list" style="background-image: url(' . get_tp_mimetype_images( 'html' ) . ')" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank">doi:' . $doi . '</a></li>';
+			}
+			else {
+				$end .= '<a class="tp_pub_link" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank"><img class="tp_pub_link_image" alt="" src="' . get_tp_mimetype_images( 'html' ) . '"/></a>';
+			}
         }
         
         if ( $mode === 'list' ) {
@@ -514,9 +516,27 @@ class tp_html_publication_template {
         
         return $end;
     }
-
-
-
+	
+	/**
+     * Prepares a doi url
+     * @param string $doi	The DOI number
+     * @return string
+     * @since 6.x.x
+     * @version 1
+     * @access public
+     */
+	public static function prepare_doi_url($doi) {
+		$doi_resolver_url_template = '';
+		
+		if ( get_tp_option('doi_resolver_url_template_custom') != '' ) {
+			$doi_resolver_url_template = get_tp_option('doi_resolver_url_template_custom');
+		} 
+		else {
+			$doi_resolver_url_template = get_tp_option('doi_resolver_url_template_default');
+		}
+		
+		return str_replace('%doi%', $doi, $doi_resolver_url_template);
+	}
 
     /**
      * Prepares an altmetric info block 


### PR DESCRIPTION
We are using teachPress in one of our projects and we had to add the possibility to define a custom doi resolver (e.g. Google Scholar) which is currently hardcoded in the `core/template.php` file. 

It would be great if this functionality could be officially added to this plugin.

Please note, there are still the following things missing since I didn't know how to implement them properly (any help here would be highly appreciated):

1. Adding the necessary configuration values holding the default and custom doi resolver url template in the `wp_teachpress_settings` table during an update of the plugin.

2. Translation of the new labels

3. Versioning in code comments 

Best regards, Matthias