### PR TITLE
Enable title links in inline mode if DOI is available. Fixes #78.

### DIFF
--- a/core/templates.php
+++ b/core/templates.php
@@ -418,7 +418,7 @@ class tp_html_publication_template {
         }
         
         // for inline style
-        elseif ( $row['url'] != '' && $settings['link_style'] === 'inline' ) {
+        elseif ( ($row['url'] != '' || $row['doi'] != '') && $settings['link_style'] === 'inline' ) {
             return '<a class="tp_title_link" onclick="teachpress_pub_showhide(' . "'" . $container_id . "'" . ',' . "'" . 'tp_links' . "'" . ')" style="cursor:pointer;">' . tp_html::prepare_title($row['title'], 'decode') . '</a>';
         }
         


### PR DESCRIPTION
Title links can be enabled when the style of the publication link is set as "inline" and the publication has a DOI.