### PR TITLE
Fixed #118 for publication list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 *.log
 .htaccess
 sitemap.xml

--- a/core/general.php
+++ b/core/general.php
@@ -427,6 +427,120 @@ function get_tp_mimetype_images($url_link) {
 }
 
 /**
+ * Returns the path to a mimetype image
+ * @param string $url   --> the icon of a file using Font Awesome and academicons
+ * @return string 
+ * @since 6.0.0
+ */
+function get_tp_mimetype_icon($url_link) {
+    $mimetype = substr($url_link,-4,4);
+    preg_match( "/^(https?:\/\/)?(.+)$/", $url_link, $urltype);
+    $urltype = preg_split("#/#", $urltype[2])[0];
+    $urltype = str_replace("www.", "", $urltype);
+    $url = plugins_url();
+    $mimetypes = array(
+        'doi' => 'ai ai-doi',
+        '.pdf' => 'fas fa-file-pdf',
+        '.doc' => 'fas fa-file-word',
+        'docx' => 'fas fa-file-word',
+        '.ppt' => 'fas fa-file-powerpoint',
+        'pptx' => 'fas fa-file-powerpoint',
+        '.xls' => 'fas fa-file-excel',
+        'xlsx' => 'fas fa-file-excel',
+        '.odt' => 'fas fa-file-word',
+        '.ods' => 'fas fa-file-excel',
+        '.odp' => 'fas fa-file-powerpoint',
+        '.odf' => 'fas fa-file-code',
+        '.odg' => 'fas fa-file-contract',
+        '.odc' => 'fas fa-file-contract',
+        '.odi' => 'fas fa-file-contract',
+        '.rtf' => 'fas fa-file-alt',
+        '.rdf' => 'fas fa-file-alt',
+        '.txt' => 'fas fa-file-alt',
+        '.tex' => 'fas fa-file-alt',
+        'html' => 'fas fa-globe',
+        'htm' => 'fas fa-globe',
+        '.php' => 'fas fa-globe',
+        '.xml' => 'fas fa-file-code',
+        '.css' => 'fas fa-file-code',
+        '.py' => 'fas fa-file-code',
+        '.ipynb' => 'fas fa-file-code',
+        '.csv' => 'fas fa-file-csv',
+        '.dat' => 'fas fa-file-alt',
+        '.db' => 'fas fa-database',
+        '.dbf' => 'fas fa-database',
+        '.log' => 'fas fa-file-alt',
+        '.mdb' => 'fas fa-database',
+        '.sql' => 'fas fa-database',
+        '.sav' => 'fas fa-file-alt',
+        '.sav' => 'fas fa-file-alt',
+        '.mid' => 'fas fa-file-audio',
+        '.midi' => 'fas fa-file-audio',
+        '.mp3' => 'fas fa-file-audio',
+        '.ogg' => 'fas fa-file-audio',
+        '.wma' => 'fas fa-file-audio',
+        '.wav' => 'fas fa-file-audio',
+        '.wpl' => 'fas fa-file-audio',
+        '.ai' => 'fas fa-file-image',
+        '.bmp' => 'fas fa-file-image',
+        '.gif' => 'fas fa-file-image',
+        '.ico' => 'fas fa-file-image',
+        '.jpg' => 'fas fa-file-image',
+        '.jpeg' => 'fas fa-file-image',
+        '.png' => 'fas fa-file-image',
+        '.psd' => 'fas fa-file-image',
+        '.svg' => 'fas fa-file-image',
+        '.dvi' => 'fas fa-file-image',
+        '.tif' => 'fas fa-file-image',
+        '.tiff' => 'fas fa-file-image',
+        '.3g2' => 'fas fa-file-video',
+        '.3gp' => 'fas fa-file-video',
+        '.avi' => 'fas fa-file-video',
+        '.flv' => 'fas fa-file-video',
+        '.h264' => 'fas fa-file-video',
+        '.m4v' => 'fas fa-file-video',
+        '.mkv' => 'fas fa-file-video',
+        '.mov' => 'fas fa-file-video',
+        '.mp4' => 'fas fa-file-video',
+        '.wmv' => 'fas fa-file-video',
+        '.mpg' => 'fas fa-file-video',
+        '.mpeg' => 'fas fa-file-video',
+        '.wmv' => 'fas fa-file-video',
+        '.7z' => 'fas fa-file-archive',
+        '.arj' => 'fas fa-file-archive',   
+        '.deb' => 'fas fa-file-archive',
+        '.pkg' => 'fas fa-file-archive',
+        '.rar' => 'fas fa-file-archive',
+        '.rpm' => 'fas fa-file-archive',
+        '.tar.gz' => 'fas fa-file-archive',
+        '.gz' => 'fas fa-file-archive',     
+        '.zip' => 'fas fa-file-archive',
+        );
+    $mediaicons = array(
+        'youtube.com' => 'fab fa-youtube',
+        'icon-vimeo.com' => 'fab fa-vimeo-v',
+        'github.com' => 'fab fa-github',
+        'gitlab.com' => 'fab fa-gitlab',
+        'overleaf.com' => 'ai ai-overleaf',
+        'arxiv.org' => 'ai ai-arxiv',
+
+    );
+
+
+    
+    if ( isset ($mimetypes[$mimetype]) ) {
+        return $mimetypes[$mimetype];
+    }
+    elseif ( isset ($mediaicons[$urltype]) ) {
+        return $mediaicons[$urltype];
+    }
+    else {
+
+        return 'fas fa-globe';
+    }
+}
+
+/**
  * Translate a publication type
  * @param string $string    The publication type
  * @param string $num       sin (singular) or pl (plural)

--- a/core/general.php
+++ b/core/general.php
@@ -436,8 +436,8 @@ function get_tp_mimetype_icon($url_link) {
     $mimetype = substr($url_link,-4,4);
     preg_match( "/^(https?:\/\/)?(.+)$/", $url_link, $urltype);
     $urltype = preg_split("#/#", $urltype[2])[0];
-    $urltype = str_replace("www.", "", $urltype);
-    $url = plugins_url();
+    $urltype = explode(".", $urltype);
+    $urltype = $urltype[count($urltype)-2].".".end($urltype);
     $mimetypes = array(
         'doi' => 'ai ai-doi',
         '.pdf' => 'fas fa-file-pdf',

--- a/core/general.php
+++ b/core/general.php
@@ -369,7 +369,8 @@ function get_tp_mimetype_images($url_link) {
     $mimetype = substr($url_link,-4,4);
     preg_match( "/^(https?:\/\/)?(.+)$/", $url_link, $urltype);
     $urltype = preg_split("#/#", $urltype[2])[0];
-    $urltype = str_replace("www.", "", $urltype);
+    $urltype = explode(".", $urltype);
+    $urltype = $urltype[count($urltype)-2].".".end($urltype);
     $url = plugins_url();
     $mimetypes = array(
         '.pdf' => $url . '/teachpress/images/mimetypes/application-pdf.png',

--- a/core/templates.php
+++ b/core/templates.php
@@ -522,11 +522,11 @@ class tp_html_publication_template {
                 if ( $length > 80 ) {
                     $parts[1] .= '[...]';
                 }
-                $end .= '<li><a class="tp_pub_list" style="background-image: url(' . get_tp_mimetype_images( $parts[0] ) . ')" href="' . $parts[0] . '" title="' . $parts[1] . '" target="_blank">' . $parts[1] . '</a></li>';
+                $end .= '<li><a class="tp_pub_list" href="' . $parts[0] . '" title="' . $parts[1] . '" target="_blank"><i class="' . get_tp_mimetype_icon( $parts[0] ).'"></i></a></li>';
             }
             // enumeration mode
             else {
-                $end .= '<a class="tp_pub_link" href="' . $parts[0] . '" title="' . $parts[1] . '" target="_blank"><img class="tp_pub_link_image" alt="" src="' . get_tp_mimetype_images( $parts[0] ) . '"/></a>';
+                $end .= '<a class="tp_pub_link" href="' . $parts[0] . '" title="' . $parts[1] . '" target="_blank"><i class="' . get_tp_mimetype_icon( $parts[0] ).'"></i></a>';
             }
         }
         
@@ -538,10 +538,10 @@ class tp_html_publication_template {
             $doi_url = TEACHPRESS_DOI_RESOLVER . $doi;
             if (in_array($doi_url, $url_displayed) == False){
                 if ( $mode === 'list' ) {
-                    $end .= '<li><a class="tp_pub_list" style="background-image: url(' . get_tp_mimetype_images( 'html' ) . ')" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank">doi:' . $doi . '</a></li>';
+                    $end .= '<li><a class="tp_pub_list" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank"><i class="' . get_tp_mimetype_icon( 'doi' ).'"></i></a></li>';
                 }
                 else {
-                    $end .= '<a class="tp_pub_link" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank"><img class="tp_pub_link_image" alt="" src="' . get_tp_mimetype_images( 'html' ) . '"/></a>';
+                    $end .= '<a class="tp_pub_link" href="' . $doi_url . '" title="' . __('Follow DOI:','teachpress') . $doi . '" target="_blank"><i class="' . get_tp_mimetype_icon( 'doi').'"></i></a>';
                 }
             }
         }

--- a/teachpress.php
+++ b/teachpress.php
@@ -588,6 +588,9 @@ function tp_frontend_scripts() {
     $version = get_tp_version();
     echo chr(13) . chr(10) . '<!-- teachPress -->' . chr(13) . chr(10);
     echo '<script type="text/javascript" src="' . plugins_url() . '/teachpress/js/frontend.js?ver=' . $version . '"></script>' . chr(13) . chr(10);
+    echo '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">' . chr(13) . chr(10);
+    echo '<link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css">' . chr(13) . chr(10);
+    
     $value = get_tp_option('stylesheet');
     if ($value == '1') {
         echo '<link type="text/css" href="' . plugins_url() . '/teachpress/styles/teachpress_front.css?ver=' . $version . '" rel="stylesheet" />' . chr(13) . chr(10);

--- a/templates/tp_template_2016.css
+++ b/templates/tp_template_2016.css
@@ -7,9 +7,9 @@ td.tp_pub_info {border-bottom:1px solid silver; vertical-align:top; padding:8px;
 .tp_pub_author, #content p.tp_pub_author {font-size:small; margin-bottom:1px; margin-top:1px;}
 .tp_pub_title, #content p.tp_pub_title {font-size:small; font-weight:bold; margin-top:1px; margin-bottom:1px;}
 .tp_pub_additional, #content p.tp_pub_additional {font-size:small; margin-top:1px; margin-bottom:1px;}
-.tp_pub_tags, #content p.tp_pub_tags  {font-size:small; margin-top:1px; margin-bottom:1px; color:#AAAAAA;}
-.tp_pub_tags a {color:#AAAAAA; text-decoration:underline; box-shadow: none;}
-.tp_pub_tags a:hover {color:#AAAAAA; text-decoration:none;}
+.tp_pub_tags, #content p.tp_pub_tags  {font-size:small; margin-top:1px; margin-bottom:1px; }
+.tp_pub_tags a {text-decoration:underline; box-shadow: none; }
+.tp_pub_tags a:hover {text-decoration:none;}
+.tp_pub_tags i {padding-left: 2px; padding-right: 2px; font-size: 140%; text-decoration: none;}
 .tp_pub_type {background-color: #008bd2; color: #fff; display: inline-block; padding: 3px 4px; margin-left: 5px; font-size: 10px; font-weight: bold; line-height: 1; border-radius: 2px; box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);}
 .tp_pub_label_status {background-color: orange; color: #fff; display: inline-block; padding: 3px 4px; margin-left: 5px; font-size: 10px; font-weight: bold; line-height: 1; border-radius: 2px; box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);}
-.tp_pub_link_image {max-width: 2em; max-height: 2em;}


### PR DESCRIPTION
Fix #118 - changelog:
* The publication list used now font-awsome and and [academicons](https://github.com/jpswalsh/academicons/). get_tp_mimetype_icon()
* I added a large set of file endings to support new common files.
* The subdomain bug is fixed.

However, the class document manager still uses get_tp_mimetype_images. I do not have a sufficient test database to test changing the class file/link icons.
@winkm89 please check class-document-manager.php line 93 if you want to use the icons there too.