### PR TITLE
Adding DOI-Link to feedlist

### DIFF
--- a/core/feeds.php
+++ b/core/feeds.php
@@ -43,7 +43,9 @@ function tp_pub_rss_feed_func () {
     foreach ($row as $row) {
 
         // prepare url
-        if ( $row['url'] != '' ) {
+        if ( $row['doi'] != '') {
+            $item_link = "https://dx.doi.org/" . $row['doi'];
+        } elseif ( $row['url'] != '' ) {
             $new = explode(', ', $row['url']);
             $item_link = $new[0];
         } elseif ($row['rel_page'] != '') {


### PR DESCRIPTION
Currently a working link will only generated in behalf of the given dedicate links.  The usually also available DOI ist actually neglected. With this change I also consider the DOI, next to dedicate given URLs, to provide a working link for the feed list.