### PR TITLE
Use plugins_url() with $path and $plugin arguments

### DIFF
--- a/admin/add-course.php
+++ b/admin/add-course.php
@@ -175,7 +175,7 @@ function tp_add_course_page() {
      </div>
       
       </form>
-      <script type="text/javascript" charset="utf-8" src="<?php echo plugins_url(); ?>/teachpress/js/admin_add_course.js"></script>
+      <script type="text/javascript" charset="utf-8" src="<?php echo plugins_url( 'js/admin_add_course.js', dirname( __FILE__ ) ); ?>"></script>
    </div>
 <?php }
 

--- a/admin/mail.php
+++ b/admin/mail.php
@@ -121,7 +121,7 @@ function tp_show_mail_page() {
         </table>
         <br />
         <input type="submit" class="button-primary" name="send_mail" value="<?php _e('Send','teachpress'); ?>"/>
-        <script type="text/javascript" charset="utf-8" src="<?php echo plugins_url(); ?>/teachpress/js/admin_mail.js"></script>
+        <script type="text/javascript" charset="utf-8" src="<?php echo plugins_url( 'js/admin_mail.js', dirname( __FILE__ ) ); ?>"></script>
         </form>
     </div>
     <?php

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -166,8 +166,8 @@ class TP_Settings_Page {
     private static function get_about_dialog () {
         echo '<div id="dialog" title="About">
                 <div style="text-align: center;">
-                <p><img src="' . plugins_url() . '/teachpress/images/misc/about.jpg" style="border-radius: 130px; width: 250px; height: 250px;" title="Photo by Dilyara Garifullina on Unsplash" /></p>
-                <p><img src="' . plugins_url() . '/teachpress/images/full.png" width="400" /></p>
+                <p><img src="' . plugins_url( 'images/misc/about.jpg', dirname( __FILE__ ) ) . '" style="border-radius: 130px; width: 250px; height: 250px;" title="Photo by Dilyara Garifullina on Unsplash" /></p>
+                <p><img src="' . plugins_url( 'images/full.png', dirname( __FILE__ ) ) . '" width="400" /></p>
                 <p style="font-size: 20px; font-weight: bold; color: #e6bb3a;">' . get_tp_option('db-version') . ' "Apple Pie"</p>
                 <p><a href="http://mtrv.wordpress.com/teachpress/">Website</a> | <a href="https://github.com/winkm89/teachPress/">teachPress on GitHub</a> | <a href="https://github.com/winkm89/teachPress/wiki">Dokumentation</a> | <a href="https://github.com/winkm89/teachPress/wiki/Changelog">Changelog</a></p>
                 <p>&copy;2008-2020 by Michael Winkler | License: GPLv2 or later<br/></p>
@@ -422,7 +422,7 @@ class TP_Settings_Page {
         
         echo '<p><input name="einstellungen" type="submit" id="teachpress_settings" value="' . __('Save') . '" class="button-primary" /></p>';
         
-        echo '<script type="text/javascript" src="' . plugins_url() . '/teachpress/js/admin_settings.js"></script>';
+        echo '<script type="text/javascript" src="' . plugins_url( 'js/admin_settings.js', dirname( __FILE__ ) ) . '"></script>';
         self::get_about_dialog();
     }
     

--- a/core/class-document-manager.php
+++ b/core/class-document-manager.php
@@ -345,7 +345,7 @@ class TP_Document_Manager {
                 decimalPoint = ',',
                 isRtl = 0;
             </script>
-            <link rel="stylesheet" id="teachpress-document-manager-css"  href="<?php echo plugins_url(); ?>/teachpress/styles/teachpress_document_manager.css?ver=<?php echo get_tp_version(); ?>" type="text/css" media="all" />
+            <link rel="stylesheet" id="teachpress-document-manager-css"  href="<?php echo plugins_url( 'styles/teachpress_document_manager.css', dirname( __FILE__ ) ) . '?ver=' . get_tp_version(); ?>" type="text/css" media="all" />
         </head>
         <?php
     }
@@ -397,10 +397,10 @@ class TP_Document_Manager {
             wp_enqueue_script('media-upload');
             add_thickbox();
     
-            wp_enqueue_script('teachpress-standard', plugins_url() . '/teachpress/js/backend.js');
+            wp_enqueue_script('teachpress-standard', plugins_url( 'js/backend.js', dirname( __FILE__ ) ) );
 
-            wp_enqueue_style('teachpress.css', plugins_url() . '/teachpress/styles/teachpress.css');
-            wp_enqueue_style('teachpress-jquery-ui.css', plugins_url() . '/teachpress/styles/jquery.ui.css');
+            wp_enqueue_style('teachpress.css', plugins_url( 'styles/teachpress.css', dirname( __FILE__ ) ) );
+            wp_enqueue_style('teachpress-jquery-ui.css', plugins_url( 'styles/jquery.ui.css', dirname( __FILE__ ) ) );
             wp_enqueue_style('teachpress-jquery-ui-dialog.css', includes_url() . '/css/jquery-ui-dialog.min.css');
 
             do_action( 'admin_print_scripts' );

--- a/core/constants.php
+++ b/core/constants.php
@@ -199,7 +199,7 @@ if ( !defined('TEACHPRESS_TEMPLATE_URL') ) {
      * This value defines the template url
      * @since 6.0.0
     */
-    define('TEACHPRESS_TEMPLATE_URL', plugins_url() . '/teachpress/templates/');}
+    define('TEACHPRESS_TEMPLATE_URL', plugins_url( 'templates/', dirname( __FILE__ ) ) );}
 
 if ( !defined('TEACHPRESS_ALTMETRIC_SUPPORT') ) {
     /**

--- a/teachpress.php
+++ b/teachpress.php
@@ -119,7 +119,7 @@ function tp_add_menu() {
     global $tp_admin_add_course_page;
     $pos = TEACHPRESS_MENU_POSITION;
 
-    $logo = (version_compare($wp_version, '3.8', '>=')) ? plugins_url() . '/teachpress/images/logo_small.png' : plugins_url() . '/teachpress/images/logo_small_black.png';
+    $logo = (version_compare($wp_version, '3.8', '>=')) ? plugins_url( 'images/logo_small.png', __FILE__ ) : plugins_url( 'images/logo_small_black.png', __FILE__ );
 
     $tp_admin_show_courses_page = add_menu_page(
             __('Course','teachpress'), 
@@ -162,7 +162,7 @@ function tp_add_menu2() {
     global $tp_admin_show_authors_page;
     global $tp_admin_edit_tags_page;
 
-    $logo = ( version_compare($wp_version, '3.8', '>=') ) ? plugins_url() . '/teachpress/images/logo_small.png' : plugins_url() . '/teachpress/images/logo_small_black.png';
+    $logo = ( version_compare($wp_version, '3.8', '>=') ) ? plugins_url( 'images/logo_small.png', __FILE__) : plugins_url( 'images/logo_small_black.png', __FILE__ );
     $pos = TEACHPRESS_MENU_POSITION;
 
     $tp_admin_all_pub_page = add_menu_page (
@@ -403,7 +403,7 @@ function tp_register_tinymce_buttons ($buttons) {
  * @since 5.0.0
  */
 function tp_register_tinymce_js ($plugins) {
-    $plugins['teachpress_tinymce'] = plugins_url() . '/teachpress/js/tinymce-plugin.js';
+    $plugins['teachpress_tinymce'] = plugins_url( 'js/tinymce-plugin.js', __FILE__ );
     return $plugins;
 }
 
@@ -423,36 +423,36 @@ function tp_backend_scripts() {
         return;
     }
     
-    wp_enqueue_style('teachpress-print-css', plugins_url() . '/teachpress/styles/print.css', false, $version, 'print');
-    wp_enqueue_script('teachpress-standard', plugins_url() . '/teachpress/js/backend.js');
-    wp_enqueue_style('teachpress.css', plugins_url() . '/teachpress/styles/teachpress.css', false, $version);
+    wp_enqueue_style('teachpress-print-css', plugins_url( 'styles/print.css', __FILE__ ), false, $version, 'print');
+    wp_enqueue_script('teachpress-standard', plugins_url( 'js/backend.js', __FILE__ ) );
+    wp_enqueue_style('teachpress.css', plugins_url( 'styles/teachpress.css', __FILE__ ), false, $version);
     wp_enqueue_script('media-upload');
     add_thickbox();
 
     /* academicons v1.8.6 */
     if ( TEACHPRESS_LOAD_ACADEMICONS === true ) {
-        wp_enqueue_style('academicons', plugins_url() . '/teachpress/includes/academicons/css/academicons.min.css');
+        wp_enqueue_style('academicons', plugins_url( 'includes/academicons/css/academicons.min.css', __FILE__ ) );
     }
 
     /* Font Awesome Free v5.10.1 */
     if (TEACHPRESS_LOAD_FONT_AWESOME === true) {
-        wp_enqueue_style('font-awesome', plugins_url() . '/teachpress/includes/fontawesome/css/all.min.css'); 
+        wp_enqueue_style('font-awesome', plugins_url( 'includes/fontawesome/css/all.min.css', __FILE__ ) );
     }
     
     /* SlimSelect v1.27 */
-    wp_enqueue_script('slim-select', plugins_url() . '/teachpress/includes/slim-select/slimselect.min.js');
-    wp_enqueue_style('slim-select.css', plugins_url() . '/teachpress/includes/slim-select/slimselect.min.css'); 
+    wp_enqueue_script('slim-select', plugins_url( 'includes/slim-select/slimselect.min.js', __FILE__ ) );
+    wp_enqueue_style('slim-select.css', plugins_url( 'includes/slim-select/slimselect.min.css', __FILE__ ) );
     
     // Load jQuery + ui plugins + plupload
     wp_enqueue_script(array('jquery-ui-core', 'jquery-ui-datepicker', 'jquery-ui-resizable', 'jquery-ui-autocomplete', 'jquery-ui-sortable', 'jquery-ui-dialog', 'plupload'));
-    wp_enqueue_style('teachpress-jquery-ui.css', plugins_url() . '/teachpress/styles/jquery.ui.css');
+    wp_enqueue_style('teachpress-jquery-ui.css', plugins_url( 'styles/jquery.ui.css', __FILE__ ) );
     wp_enqueue_style('teachpress-jquery-ui-dialog.css', includes_url() . '/css/jquery-ui-dialog.min.css');
     
     // Languages for plugins
     $current_lang = ( version_compare( tp_get_wp_version() , '4.0', '>=') ) ? get_option('WPLANG') : WPLANG;
     $array_lang = array('de_DE','it_IT','es_ES', 'sk_SK');
     if ( in_array( $current_lang , $array_lang) ) {
-        wp_enqueue_script('teachpress-datepicker-de', plugins_url() . '/teachpress/js/datepicker/jquery.ui.datepicker-' . $current_lang . '.js');
+        wp_enqueue_script('teachpress-datepicker-de', plugins_url( 'js/datepicker/jquery.ui.datepicker-' . $current_lang . '.js', __FILE__ ) );
     }
 }
 
@@ -467,12 +467,12 @@ function tp_frontend_scripts() {
     echo PHP_EOL . '<!-- teachPress -->' . PHP_EOL;
 
     /* tp-frontend script */
-    echo '<script' . $type_attr . ' src="' . plugins_url() . '/teachpress/js/frontend.js?ver=' . $version . '"></script>' . PHP_EOL;
+    echo '<script' . $type_attr . ' src="' . plugins_url( 'js/frontend.js?ver=' . $version, __FILE__ ) . '"></script>' . PHP_EOL;
 
     /* tp-frontend style */
     $value = get_tp_option('stylesheet');
     if ($value == '1') {
-        echo '<link type="text/css" href="' . plugins_url() . '/teachpress/styles/teachpress_front.css?ver=' . $version . '" rel="stylesheet" />' . PHP_EOL;
+        echo '<link type="text/css" href="' . plugins_url( 'styles/teachpress_front.css?ver=' . $version, __FILE__ ) . '" rel="stylesheet" />' . PHP_EOL;
     }
 
     /* altmetric support */
@@ -482,12 +482,12 @@ function tp_frontend_scripts() {
 
     /* academicons v1.8.6 */
     if ( TEACHPRESS_LOAD_ACADEMICONS === true ) {
-        wp_enqueue_style('academicons', plugins_url() . '/teachpress/includes/academicons/css/academicons.min.css');
+        wp_enqueue_style('academicons', plugins_url( 'includes/academicons/css/academicons.min.css', __FILE__ ) );
     }
 
     /* Font Awesome Free 5.10.1 */
     if (TEACHPRESS_LOAD_FONT_AWESOME === true) {
-        wp_enqueue_style('font-awesome', plugins_url() . '/teachpress/includes/fontawesome/css/all.min.css');
+        wp_enqueue_style('font-awesome', plugins_url( 'includes/fontawesome/css/all.min.css', __FILE__ ) );
     }
 
     /* END */


### PR DESCRIPTION
This means that the plugin directory does not have to be `teachpress` but can be arbitrarily named, which in turn means that there can be several teachPress installations within the same WordPress.  This is probably only of concern to those working on the code.

This is discussed in the [WordPress documentation](https://developer.wordpress.org/reference/functions/plugins_url/); the `dirname()` usage is mentioned in the user-contributed notes.