### PR TITLE
Improved diacritic import

### DIFF
--- a/admin/import-publications.php
+++ b/admin/import-publications.php
@@ -129,7 +129,7 @@ class TP_Import_Publication_Page {
                 }
             }
             else {
-                $bibtex = $bibtex_area;
+                $bibtex = stripslashes($bibtex_area);
             }
 
             $settings = array(

--- a/core/publications/class-bibtex.php
+++ b/core/publications/class-bibtex.php
@@ -44,7 +44,7 @@ class TP_Bibtex {
         "\\textuparrow"          => "↑",
         "\\textrightarrow"       => "→",
         "\\textdownarrow"        => "↓",
-        "$\\infty$"                => "∞",
+        "$\\infty$"              => "∞",
         "\\textlangle"           => "〈",
         "\\textrangle"           => "〉",
         "\\textvisiblespace"     => "␣",
@@ -153,9 +153,6 @@ class TP_Bibtex {
         "\\dh"                   => "ð",
         "\\DJ"                   => "Đ",
         "\\dj"                   => "đ",
-        "\\i"                    => "ı",
-        "\\L"                    => "Ł",
-        "\\l"                    => "ł",
         "\\NG"                   => "Ŋ",
         "\\ng"                   => "ŋ",
         "\\O"                    => "Ø",
@@ -283,7 +280,12 @@ class TP_Bibtex {
         "\\H u"                  => "ű",
         "\\v Z"                  => "Ž",
         "\\v z"                  => "ž",
-        
+   
+        // later in the dict so that they don't match longer entries like "\\'\\i"
+        "\\i"                    => "ı",
+        "\\L"                    => "Ł",
+        "\\l"                    => "ł",
+                                               
         // for custom latex packages like ngerman
         "\\glqq"                 => "„",
         "\\grqq"                 => "“",


### PR DESCRIPTION
When bibtex code is pasted in the import textarea, then POSTed, it is stripped of its slashes to undo WP's magic quote default behavior. This magic quote default behavior corrupts the bibtex code in a way that is specific to the textarea, i.e. it is not activated when a file is imported. Because of this inconsistent behavior (textarea vs file), bugs appeared. This should be fixed with this pull request. This should fix #212 for most characters.