### PR TITLE
Changed author format to 'dynamic' in auto-publish

### DIFF
--- a/admin/publication-sources.php
+++ b/admin/publication-sources.php
@@ -358,7 +358,7 @@ class TP_Publication_Sources_Page {
                         } else {
                             $settings = array(
                                 'keyword_separator' => ',',
-                                'author_format'     => 'author_format_1',
+                                'author_format'     => 'dynamic',
                                 'overwrite'         => true,
                                 'ignore_tags'       => false,
                             );


### PR DESCRIPTION
When auto-publishing bibtex from the web, use 'dynamic' author name format rather than 'author_format_1'. This should solve #225 . When auto-publishing, the following settings are henceforth used:
```php
                                'keyword_separator' => ',',
                                'author_format'     => 'dynamic',
                                'overwrite'         => true,
                                'ignore_tags'       => false,
``` 
Ideally, this should be configurable by source, but this is not presently implemented.