### PR TITLE
additional setting to group repeated citations

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -297,6 +297,17 @@ class TP_Settings_Page {
                   </td>';  
         echo '</tr>';
 
+
+        // Bibliography style
+        echo '<tr>';
+        echo '<th colspan="3"><h3>' . __('Bibliography style','teachpress') . '</h3></th>';
+        echo '</tr>';
+
+        echo '<tr>';
+        echo '<th>' . __('Repeated citations','teachpress') . '</th>';
+        echo '<td colspan="2">' . TP_Admin::get_checkbox('ref_grouped', __('Cite every reference only once','teachpress'), get_tp_option('ref_grouped')) . '</td>';
+        echo '</tr>';
+
         // Misc
         echo '<tr>';
         echo '<th colspan="3"><h3>' . __('Misc','teachpress') . '</h3></th>';
@@ -734,6 +745,7 @@ class TP_Settings_Page {
         $checkbox_convert_bibtex = isset( $_POST['convert_bibtex'] ) ? 1 : '';
         $checkbox_import_overwrite = isset( $_POST['import_overwrite'] ) ? 1 : '';
         $checkbox_rel_content_auto = isset( $_POST['rel_content_auto'] ) ? 1 : '';
+        $checkbox_ref_grouped = isset( $_POST['ref_grouped'] ) ? 1 : '';
     
         TP_Options::change_option('sem', $option_semester);
         TP_Options::change_option('rel_page_publications', $option_rel_page_publications);
@@ -745,6 +757,7 @@ class TP_Settings_Page {
         TP_Options::change_option('rel_content_template', $_POST['rel_content_template']);
         TP_Options::change_option('rel_content_category', $_POST['rel_content_category']);
         tp_update_userrole($option_userrole_publications, 'use_teachpress');
+        TP_Options::change_option('ref_grouped', $checkbox_ref_grouped, 'checkbox');
 
         get_tp_message( __('Settings are changed. Please note that access changes are visible, until you have reloaded this page a second time.','teachpress') );
     }

--- a/core/class-tables.php
+++ b/core/class-tables.php
@@ -145,6 +145,7 @@ class TP_Tables {
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('rel_content_category', '', 'system')");
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('import_overwrite', '1', 'system')");
         $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('convert_bibtex', '0', 'system')");
+        $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('ref_grouped', '0', 'system')");
        
     }
     

--- a/core/class-update.php
+++ b/core/class-update.php
@@ -1113,10 +1113,17 @@ class TP_Update {
             $value = 'name = {matriculation_number}, title = {Matriculation number}, type = {INT}, required = {false}, min = {1}, max = {1000000}, step = {1}, visibility = {admin}';
             $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('matriculation_number', '$value', 'teachpress_stud')");
         }
+
         /**** since version 5.0.3 ****/
         // Fix an installer bug (wrong template for related content)
         if ( get_tp_option('rel_content_template') == 'page' ) {
             TP_Options::change_option('rel_content_template', '[tpsingle [key]]<!--more-->' . "\n\n[tpabstract]\n\n[tplinks]\n\n[tpbibtex]");
+        }
+
+        /**** since version 9.0.3 ****/
+        // group references
+        if ($wpdb->query("SELECT value FROM " . TEACHPRESS_SETTINGS . " WHERE `variable` = 'ref_grouped' AND `category` = 'system'") == '0') {
+            $wpdb->query("INSERT INTO " . TEACHPRESS_SETTINGS . " (`variable`, `value`, `category`) VALUES ('ref_grouped', '0', 'system')");
         }
     }
     

--- a/core/publications/class-cite-object.php
+++ b/core/publications/class-cite-object.php
@@ -5,7 +5,7 @@
  */
 class TP_Cite_Object {
     
-    // stores the citations
+    // stores the association between id and citation
     var $cite_object = array();
     
     /**
@@ -14,19 +14,38 @@ class TP_Cite_Object {
      * @since 5.2.0
      */
     public function get_count() {
-        $count = count($this->cite_object);
-        return $count;
+        return count($this->cite_object);
     }
     
     /**
      * Adds a citation to the cite object
      * @param array $cite
+     * @return the index of the citation in the cite object
      * @since 5.2.0
      */
     public function add_ref($cite) {
-        $count = $this->get_count();
-        $count = $count + 1;
-        array_push($this->cite_object, $cite);
+        // Get global option
+        $ref_grouped = ( get_tp_option('ref_grouped') == '1' ) ? true : false;
+
+        // add the citation
+        if ($ref_grouped) {
+            // did we already added this citation?
+            $existing_index = array_search($cite['pub_id'], array_keys($this->cite_object));
+            if ($existing_index === false) {
+                // first time we see this publication, adding it
+                $this->cite_object[$cite['pub_id']] = $cite;
+                // so this publication is the last of our list
+                return $this->get_count();
+            } else {
+                // we already added this publication in the past
+                return $existing_index + 1;
+            }
+        } else {
+            // add this citation
+            array_push($this->cite_object, $cite);
+            // so this publication is the last of our list
+            return $this->get_count();
+        }
     }
     
     /**
@@ -35,7 +54,7 @@ class TP_Cite_Object {
      * @since 5.2.0
      */
     public function get_ref() {
-        return $this->cite_object;
+        return array_values($this->cite_object);
     }
 }
 

--- a/core/shortcodes.php
+++ b/core/shortcodes.php
@@ -818,14 +818,11 @@ function tp_cite_shortcode ($atts) {
         $publication = TP_Publications::get_publication($param['id'], ARRAY_A);
     }
 
-    // Count ref number
-    $count = $tp_cite_object->get_count();
-
     // Add ref to cite object
-    $tp_cite_object->add_ref($publication);
+    $index = $tp_cite_object->add_ref($publication);
 
     // Return
-    return '<sup><a href="#tp_cite_' . $publication['pub_id'] . '">[' . ( $count + 1 ) . ']</a></sup>';
+    return '<sup><a href="#tp_cite_' . $publication['pub_id'] . '">[' . $index . ']</a></sup>';
 }
 
 /**

--- a/core/shortcodes.php
+++ b/core/shortcodes.php
@@ -17,8 +17,8 @@ class TP_Shortcodes {
      * Generates and returns filter for the shortcodes
      * @param string $key                   year/type/author/user/tag
      * @param array $filter_parameter       An associative array with filter parameter (user input). The keys are: year, type, author, user
-     * @param array $sql_parameter          An assosciative array with SQL search parameter (user, type, exclude, exclude_tags, order)
-     * @param array $settings               An assosciative array with settings (permalink, html_anchor,...)
+     * @param array $sql_parameter          An associative array with SQL search parameter (user, type, exclude, exclude_tags, order)
+     * @param array $settings               An associative array with settings (permalink, html_anchor,...)
      * @param int $tabindex                 The tabindex
      * @return string
      * @since 5.0.0
@@ -429,8 +429,8 @@ class TP_Shortcodes {
      * Returns a tag cloud
      * @param int $user                 The user ID
      * @param array $filter_parameter   An associative array with filter parameter (user input). The keys are: year, type, author, user
-     * @param array $sql_parameter      An assosciative array with SQL search parameter (user, type)
-     * @param array $settings           An assosciative array with settings (permalink, html_anchor, tag_limit, maxsize, minsize)
+     * @param array $sql_parameter      An associative array with SQL search parameter (user, type)
+     * @param array $settings           An associative array with settings (permalink, html_anchor, tag_limit, maxsize, minsize)
      * @return string
      * @since 5.0.0
      * @access public


### PR DESCRIPTION
adds an option in the settings of the plugin to deal with repeated citations (when using `tpcite` and `tpref`) #226.

The default behaviour is the current one (one cite = one ref). Grouping means bibtex-like citation with one unique id = one ref. 

points of attention:
- requires a change in settings, so in the database. Tested with both installation from scratch and update of an existing installing, but double checking the code is always better. 
- double check the naming of the option in the settings page
