### PR TITLE
Return proper string value in filter hook handler.

### DIFF
--- a/teachpress.php
+++ b/teachpress.php
@@ -201,7 +201,7 @@ function tp_show_screen_options($current, $screen) {
     global $tp_admin_show_authors_page;
 
     if( !is_object($screen) ) {
-        return;
+        return $current;
     }
 
     // Show screen options for the authors page


### PR DESCRIPTION
The filter hook handler function must return a string in all cases. `return;` corresponds to a return value of `null`.

Reported and analyzed in https://wordpress.org/support/topic/cannot-edit-tables-after-update-need-help/ .