### PR TITLE
Added OSF logo to the links

### DIFF
--- a/core/class-icons.php
+++ b/core/class-icons.php
@@ -143,6 +143,7 @@ class TP_Icons {
     private static function web () {
         $web = array(
             'arxiv.org' => 'ai ai-arxiv',
+            'osf.io' => 'ai ai-osf',
             'github.com' => 'fab fa-github',
             'gitlab.com' => 'fab fa-gitlab',
             'mendeley.com' => 'ai ai-mendeley',


### PR DESCRIPTION
The logo for https://osf.io was missing. To better promote open science, I think adding OSF will be necessary. So I simply added the one line of code.

Thanks.