### PR TITLE
fix warming "Deprecated Creation of dynamic property" - PHP 8.2

### DIFF
--- a/core/publications/templates.php
+++ b/core/publications/templates.php
@@ -217,7 +217,7 @@ class TP_Publication_Template_API {
     public function get_type($container = 'span') {
         $type = $this->data['row']['type'];
         if ( $container !== '' ) {
-            return '<' . $container . ' class="tp_pub_type ' . $type . '">' . tp_translate_pub_type($type) . '</' . $container . '>';
+            return '<' . $container . ' class="tp_pub_type tp_  ' . $type . '">' . tp_translate_pub_type($type) . '</' . $container . '>';
         }
         return $type;
     }

--- a/includes/bibtexParse/BIBTEXPARSE.php
+++ b/includes/bibtexParse/BIBTEXPARSE.php
@@ -81,8 +81,26 @@ This array will be empty unless the following condition is met:
  */
 class BIBTEXPARSE {
 
+    public array $preamble;
+    public array $strings;
+    public array $undefinedStrings;
+    public array $entries;
+    public int $count;
+    public bool $fieldExtract;
+    public bool $removeDelimit;
+    public bool $expandMacro;
+    public bool $parseFile;
+    public bool $outsideEntry;
+	public array $userStrings= [];
+	public array $bibtexString = [];
+	public int $currentLine;
+
     public function __construct() {
-        $this->preamble = $this->strings = $this->undefinedStrings = $this->entries = array();
+        $this->preamble = [];
+        $this->strings = [];
+        $this->undefinedStrings = [];
+        $this->entries = [];
+
         $this->count = 0;
         $this->fieldExtract = TRUE;
         $this->removeDelimit = TRUE;


### PR DESCRIPTION
Starting from PHP 8.2, Dynamic Properties in object is deprecated. 

`Deprecated: Creation of dynamic property BIBTEXPARSE::$entries is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 85

Deprecated: Creation of dynamic property BIBTEXPARSE::$undefinedStrings is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 85

Deprecated: Creation of dynamic property BIBTEXPARSE::$strings is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 85

Deprecated: Creation of dynamic property BIBTEXPARSE::$preamble is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 85

Deprecated: Creation of dynamic property BIBTEXPARSE::$count is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 86

Deprecated: Creation of dynamic property BIBTEXPARSE::$fieldExtract is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 87

Deprecated: Creation of dynamic property BIBTEXPARSE::$removeDelimit is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 88

Deprecated: Creation of dynamic property BIBTEXPARSE::$expandMacro is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 89

Deprecated: Creation of dynamic property BIBTEXPARSE::$parseFile is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 90

Deprecated: Creation of dynamic property BIBTEXPARSE::$outsideEntry is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 91

Deprecated: Creation of dynamic property BIBTEXPARSE::$userStrings is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 131

Deprecated: Creation of dynamic property BIBTEXPARSE::$bibtexString is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 116

Deprecated: Creation of dynamic property BIBTEXPARSE::$currentLine is deprecated in /var/www/clients/client5/web840/web/wp-content/plugins/teachpress/includes/bibtexParse/BIBTEXPARSE.php on line 122`