### PR TITLE
Author search by name

### DIFF
--- a/core/publications/class-db-authors.php
+++ b/core/publications/class-db-authors.php
@@ -21,6 +21,7 @@ class TP_Authors  {
     * In this case you should ignore the columns con_id and pub_id from return   
     * 
     * @param array $args {
+    *       @type string author         Author names (separated by comma)
     *       @type string author_id      Author IDs (separated by comma)
     *       @type string pub_id         Publication IDs (separated by comma)
     *       @type string user           User IDs (separated by comma)
@@ -39,6 +40,7 @@ class TP_Authors  {
     */
     public static function get_authors ( $args = array() ) {
         $defaults = array(
+           'author'             => '',
            'author_id'          => '',
            'pub_id'             => '',
            'user'               => '',
@@ -74,7 +76,9 @@ class TP_Authors  {
         $search = esc_sql(htmlspecialchars(stripslashes($atts['search'])));
         
         $nwhere = array();
-        $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['author_id'], "r.author_id", "OR", "=");
+        $nwhere[] = TP_DB_Helpers::compose_clause( array(
+                    TP_DB_Helpers::generate_where_clause($atts['author'], "r.name", "OR", "="),
+                    TP_DB_Helpers::generate_where_clause($atts['author_id'], "r.author_id", "OR", "=")), "OR", '' );
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['pub_id'], "r.pub_id", "OR", "=");
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['exclude'], "r.author_id", "AND", "!=");
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['user'], "u.user", "OR", "=");

--- a/core/publications/class-db-publications.php
+++ b/core/publications/class-db-publications.php
@@ -175,10 +175,11 @@ class TP_Publications {
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['tag'], "b.tag_id", "OR", "=");
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['tag_name'], "t.name", "OR", "=");
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['key'], "p.bibtex", "OR", "=");
-        $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['author_id'], "r.author_id", "OR", "=");
+        $nwhere[] = TP_DB_Helpers::compose_clause( array(
+                    TP_DB_Helpers::generate_where_clause($atts['author_id'], "r.author_id", "OR", "="),
+                    TP_DB_Helpers::generate_where_clause($atts['author'], "p.author", "OR", "LIKE", '%')), "OR", '' );
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['import_id'], "p.import_id", "OR", "=");
         $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['editor'], "p.editor", "OR", "LIKE", '%');
-        $nwhere[] = TP_DB_Helpers::generate_where_clause($atts['author'], "p.author", "OR", "LIKE", '%');
         $nwhere[] = ( $atts['author_id'] != '' && $atts['include_editor_as_author'] === false) ? " AND ( r.is_author = 1 ) " : null;
         $nwhere[] = ( $search != '') ? $search : null;
         
@@ -218,9 +219,10 @@ class TP_Publications {
             // get_tp_message($sql,'red');
         }
         else {
+
             $sql = "SELECT COUNT( pub_id ) AS `count` FROM ( $select_for_count $join $where $having) p ";
         }
-        
+
         $sql = ( $count != true ) ? $wpdb->get_results($sql, $atts['output_type']): $wpdb->get_var($sql);
         return $sql;
     }

--- a/core/shortcodes.php
+++ b/core/shortcodes.php
@@ -1081,7 +1081,7 @@ function tp_links_shortcode ($atts) {
  *      @type string user                  the WordPress IDs or login names of on or more users (separated by commas)
  *      @type string tag                   tag IDs (separated by comma)
  *      @type string type                  the publication types you want to show (separated by comma)
- *      @type string author                author IDs (separated by comma)
+ *      @type string author                author IDs or names (separated by comma). If the entry is numeric then it is interpreted as an ID, otherwise as an author name.
  *      @type string year                  one or more years (separated by comma)
  *      @type string exclude               one or more IDs of publications you don't want to show (separated by comma)
  *      @type string include               one or more IDs of publications you want to show (separated by comma)

--- a/core/shortcodes.php
+++ b/core/shortcodes.php
@@ -70,8 +70,20 @@ class TP_Shortcodes {
             // Use the visible filter o the SQL parameter
             $author_id = ($filter_parameter['show_in_author_filter'] !== '') ? $filter_parameter['show_in_author_filter'] : $filter_parameter['author_preselect'];
 
+            $author_ids = '';
+            $author_names = '';
+            $authors = explode(",", $author_id);
+            foreach ( $authors as $author ) {
+                if ( ctype_digit($author) ) {
+                    $author_ids .= $author . ',';
+                } else {
+                    $author_names .= $author . ',';
+                }
+            }
+
             $row = TP_Authors::get_authors( array( 'user'           => $sql_parameter['user'],
-                                                   'author_id'      => $author_id,
+                                                   'author'         => $author_names,
+                                                   'author_id'      => $author_ids,
                                                    'output_type'    => ARRAY_A,
                                                    'group_by'       => true ) );
             $defaults['url_slug'] = 'auth';
@@ -1398,6 +1410,18 @@ function tp_publist_shortcode ($args) {
         $sql_parameter['order'] = "year DESC, type ASC, date DESC";
     }
 
+    // Separate authors names from authors IDs
+    $author_ids = '';
+    $author_names = '';
+    $authors = explode(",", $sql_parameter['author']);
+    foreach ( $authors as $author ) {
+        if ( ctype_digit($author) ) {
+            $author_ids .= $author . ',';
+        } else {
+            $author_names .= $author . ',';
+        }
+    }
+
     // Parameters for returning publications
     $args = array(
         'tag'                       => $sql_parameter['tag'],
@@ -1407,7 +1431,8 @@ function tp_publist_shortcode ($args) {
         'type'                      => $sql_parameter['type'],
         'user'                      => $sql_parameter['user'],
         'search'                    => $filter_parameter['search'],
-        'author_id'                 => $sql_parameter['author'],
+        'author'                    => $author_names,
+        'author_id'                 => $author_ids,
         'order'                     => $sql_parameter['order'],
         'exclude'                   => $sql_parameter['exclude'],
         'exclude_tags'              => $sql_parameter['exclude_tags'],


### PR DESCRIPTION
Hi,
I expanded the search function allowing to use the author name as a filter, other than their ID.
As the infrastructure to do so is already largely in place, the only change is to split the author list and check each token to see if it is numeric or not, and recreate two lists - one for author IDs and one for author names.

This way inside the shortcodes is possible to specify any combination of `author=1,3,42`, `author=J. Smith,Jane Doe`, or `author=1,Jane Doe,42`, and the search will return all the publication that matches at least one of them (with partial matches for author names, as they are passed to a `LIKE %name%` clause).

This change is mostly backwards compatible, as lists of numeric author IDs in shortcodes are processed the same as before, while the functions `TP_Authors::get_authors()` and `TP_Publications::get_publications()` now return entries that matches at least one of those passed in `author` and `author_id` instead of both of them - but I'm not sure if is was ever possible to specify both using publicly available functions.
