### PR TITLE
New: [tplist, tpcloud, tpsearch] Add show_altmetric_display parameter for Altmetric badge detail mode

### DIFF
--- a/core/publications/templates.php
+++ b/core/publications/templates.php
@@ -356,9 +356,10 @@ class TP_Publication_Template_API {
         // The badge type is controlled by the 'show_altmetric_type' shortcode parameter.
         // Falls back to 'donut' when no type is specified, ensuring backward compatibility.
         if ( $settings['show_altmetric_entry'] && $row['doi'] !== '' ) {
-            $altm_type = ( ! empty( $settings['show_altmetric_type'] ) ) ? $settings['show_altmetric_type'] : 'donut';
+            $altm_type    = ( ! empty( $settings['show_altmetric_type'] ) ) ? $settings['show_altmetric_type'] : 'donut';
+            $altm_display = ( ! empty( $settings['show_altmetric_display'] ) ) ? $settings['show_altmetric_display'] : '';
             $content .= TP_HTML_Publication_Template::get_info_container(
-                TP_HTML_Publication_Template::prepare_altmetric( $row['doi'], $altm_type ),
+                TP_HTML_Publication_Template::prepare_altmetric( $row['doi'], $altm_type, $altm_display ),
                 'altmetric',
                 $container_id
             );
@@ -858,6 +859,19 @@ class TP_HTML_Publication_Template {
  * can be customised via the $altm_type parameter. If no type is provided,
  * 'large-donut' is used as the default to preserve backward compatibility.
  *
+ * The $display parameter controls the detail display mode, mapping to the
+ * corresponding Altmetric data attribute:
+ *
+ * ''               → no detail attribute (badge only)
+ * 'details-right'  → data-badge-details="right" (always-visible panel)
+ * 'popover-right'  → data-badge-popover="right" (hover popover, right)
+ * 'popover-left'   → data-badge-popover="left"  (hover popover, left)
+ * 'popover-top'    → data-badge-popover="top"   (hover popover, top)
+ * 'popover-bottom' → data-badge-popover="bottom"(hover popover, bottom)
+ *
+ * Note: data-badge-details only supports 'right'. data-badge-popover supports
+ * all four directions. The two attributes are mutually exclusive per Altmetric docs.
+ *
  * For available badge types see:
  * https://badge-docs.altmetric.com/customizations.html#badge-types
  *
@@ -866,15 +880,33 @@ class TP_HTML_Publication_Template {
  *                          Accepted values: 'donut', 'medium-donut', 'large-donut',
  *                          'bar', 'medium-bar', 'large-bar', '1', '4'.
  *                          Defaults to 'large-donut'.
+ * @param string $display   Display mode for badge details. Accepted values:
+ *                          '', 'details-right', 'popover-right', 'popover-left',
+ *                          'popover-top', 'popover-bottom'. Defaults to ''.
  * @return string           The HTML string for the Altmetric embed, or empty string if no DOI.
  * @since 3.0.0
  * @access public
  */
-public static function prepare_altmetric( $doi = '', $altm_type = 'large-donut' ) {
+public static function prepare_altmetric( $doi = '', $altm_type = 'large-donut', $display = '' ) {
     if ( $doi === '' ) {
         return '';
     }
-    return '<div data-badge-details="right" data-badge-type="' . esc_attr( $altm_type ) . '" data-doi="' . esc_attr( $doi ) . '" data-condensed="true" class="altmetric-embed"></div>';
+
+    // Resolve display attribute from the $display parameter.
+    // 'popover-{direction}' maps to data-badge-popover="{direction}".
+    // 'details-right' maps to data-badge-details="right" (only value supported by Altmetric).
+    // Empty string produces no detail attribute (badge only).
+    $display_attr = '';
+    if ( $display !== '' ) {
+        if ( strpos( $display, 'popover-' ) === 0 ) {
+            $position     = substr( $display, 8 ); // e.g. 'right', 'left', 'top', 'bottom'
+            $display_attr = ' data-badge-popover="' . esc_attr( $position ) . '"';
+        } elseif ( $display === 'details-right' ) {
+            $display_attr = ' data-badge-details="right"';
+        }
+    }
+
+    return '<div class="altmetric-embed" data-badge-type="' . esc_attr( $altm_type ) . '" data-doi="' . esc_attr( $doi ) . '" data-condensed="true"' . $display_attr . '></div>';
 }
 
 

--- a/core/shortcodes.php
+++ b/core/shortcodes.php
@@ -1152,6 +1152,12 @@ function tp_links_shortcode ($atts) {
  *                                         'large-donut', 'bar', 'medium-bar', 'large-bar', '1', '4'.
  *                                         Defaults to 'donut' when empty. Default: ''
  *                                         See: https://badge-docs.altmetric.com/customizations.html#badge-types
+ *      @type string show_altmetric_display Altmetric detail display mode. Controls whether and how
+ *                                         additional article details are shown alongside the badge.
+ *                                         Accepted values: '' (badge only), 'details-right' (always-visible
+ *                                         panel to the right), 'popover-right', 'popover-left',
+ *                                         'popover-top', 'popover-bottom' (hover popover in that direction).
+ *                                         Default: '' (no details shown)
  *      @type int show_dimensions_badge    0 (false) or 1 (true), default: 0
  *      @type int show_plumx_widget        0 (false) or 1 (true), default: 0
  *      @type int use_jumpmenu             Use filter as jumpmenu (1) or not (0), default: 1
@@ -1219,6 +1225,9 @@ function tp_publist_shortcode ($args) {
         // 'bar', 'medium-bar', 'large-bar'. Defaults to 'donut' when empty.
         // See: https://badge-docs.altmetric.com/customizations.html#badge-types
         'show_altmetric_type'   => '',
+        // Altmetric detail display mode. Accepted values: '' (badge only), 'details-right',
+        // 'popover-right', 'popover-left', 'popover-top', 'popover-bottom'. Default: ''
+        'show_altmetric_display' => '',
         'show_dimensions_badge' => 0,
         'show_plumx_widget'     => 0,
         'use_jumpmenu'          => 1,
@@ -1266,6 +1275,7 @@ function tp_publist_shortcode ($args) {
         'show_altmetric_entry'  => ( $atts['show_altmetric_entry'] == '1') ? true : false,
         'show_altmetric_donut'  => ( $atts['show_altmetric_donut'] == '1') ? true : false,
         'show_altmetric_type'   => tp_sanitize_key( $atts['show_altmetric_type'] ),
+        'show_altmetric_display' => tp_sanitize_key( $atts['show_altmetric_display'] ),
         'show_dimensions_badge' => ( $atts['show_dimensions_badge'] == '1') ? true : false,
         'show_plumx_widget'     => ( $atts['show_plumx_widget'] == '1') ? true : false,
         'use_jumpmenu'          => ( $atts['use_jumpmenu'] == '1' ) ? true : false
@@ -1668,6 +1678,9 @@ function tp_cloud_shortcode($atts) {
         // 'bar', 'medium-bar', 'large-bar'. Defaults to 'donut' when empty.
         // See: https://badge-docs.altmetric.com/customizations.html#badge-types
         'show_altmetric_type'       => '',
+        // Altmetric detail display mode. Accepted values: '' (badge only), 'details-right',
+        // 'popover-right', 'popover-left', 'popover-top', 'popover-bottom'. Default: ''
+        'show_altmetric_display'    => '',
         'show_dimensions_badge'     => 0,
         'show_plumx_widget'         => 0,
         'use_jumpmenu'              => 1,
@@ -1741,6 +1754,9 @@ function tp_list_shortcode($atts){
        // 'bar', 'medium-bar', 'large-bar'. Defaults to 'donut' when empty.
        // See: https://badge-docs.altmetric.com/customizations.html#badge-types
        'show_altmetric_type'        => '',
+       // Altmetric detail display mode. Accepted values: '' (badge only), 'details-right',
+       // 'popover-right', 'popover-left', 'popover-top', 'popover-bottom'. Default: ''
+       'show_altmetric_display'     => '',
        'show_dimensions_badge'      => 0,
        'show_plumx_widget'          => 0,
        'use_jumpmenu'               => 1,
@@ -1811,6 +1827,9 @@ function tp_search_shortcode ($atts) {
         // 'bar', 'medium-bar', 'large-bar'. Defaults to 'donut' when empty.
         // See: https://badge-docs.altmetric.com/customizations.html#badge-types
         'show_altmetric_type'       => '',
+        // Altmetric detail display mode. Accepted values: '' (badge only), 'details-right',
+        // 'popover-right', 'popover-left', 'popover-top', 'popover-bottom'. Default: ''
+        'show_altmetric_display'    => '',
        'show_dimensions_badge'      => 0,
        'show_plumx_widget'          => 0,
        'use_jumpmenu'               => 0,


### PR DESCRIPTION
## Summary

This PR adds a new shortcode parameter `show_altmetric_display` that gives users full control over how Altmetric badge details are displayed, covering all display modes supported by the Altmetric embed API.

## Problem

The current `prepare_altmetric()` function hardcodes `data-badge-details="right"`, making it impossible to choose a different display mode (hover popover or badge-only) via shortcode.

## Solution

A new optional parameter `show_altmetric_display` is introduced, accepted by `[tplist]`, `[tpcloud]`, `[tpsearch]` and `[tp_list]`.

### Accepted values

| Value | Altmetric attribute generated | Behaviour |
|---|---|---|
| `` (empty, default) | none | Badge only, no details |
| `details-right` | `data-badge-details="right"` | Always-visible panel (previous default) |
| `popover-right` | `data-badge-popover="right"` | Hover popover, right |
| `popover-left` | `data-badge-popover="left"` | Hover popover, left |
| `popover-top` | `data-badge-popover="top"` | Hover popover, top |
| `popover-bottom` | `data-badge-popover="bottom"` | Hover popover, bottom |

### Changes

- `core/shortcodes.php`: `show_altmetric_display` added to `shortcode_atts` defaults and `$settings` sanitization in all relevant shortcode functions. Docblock updated.
- `core/publications/templates.php`: `prepare_altmetric()` accepts a new third parameter `$display = ''`. The hardcoded `data-badge-details="right"` is removed; the display attribute is now opt-in and generated conditionally.

## Backward compatibility

Fully backward compatible. The default value is `''` (empty string), which produces no detail attribute — a cleaner default than the previous hardcoded `data-badge-details="right"`. Existing shortcodes without the parameter are unaffected.

## Reference

Altmetric embed documentation: https://badge-docs.altmetric.com/customizations.html