### PR TITLE
Add teachPress Filter widget with FSE block support

### DIFF
--- a/core/publications/class-filter-widget.php
+++ b/core/publications/class-filter-widget.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * This file contains the teachPress Filter Widget class and its FSE block registration.
+ *
+ * @package teachpress\core\widgets
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GPLv2 or later
+ * @since   9.0.13
+ */
+
+
+/**
+ * teachPress Filter widget class
+ *
+ * Renders a list of publication years or tags as filter links,
+ * compatible with the teachPress shortcodes [tplist], [tpcloud], [tpsearch].
+ *
+ * @since 9.0.13
+ */
+class TP_Filter_Widget extends WP_Widget {
+
+    /**
+     * Constructor
+     */
+    function __construct() {
+        $widget_ops  = [
+            'classname'   => 'widget_teachpress_filter',
+            'description' => esc_html__( 'Filters a teachPress publication list by year or tag', 'teachpress' ),
+        ];
+        $control_ops = array( 'width' => 500, 'height' => 350 );
+        parent::__construct( false, $name = esc_html__( 'teachPress Filter', 'teachpress' ), $widget_ops, $control_ops );
+    }
+
+    /**
+     * Widget front-end output
+     *
+     * @see    WP_Widget::widget
+     * @param  array $args     Display arguments (before_widget, after_widget, etc.)
+     * @param  array $instance Saved widget settings
+     */
+    function widget( $args, $instance ) {
+        $title       = apply_filters( 'widget_title', isset( $instance['title'] )       ? $instance['title']              : '' );
+        $mode        = isset( $instance['mode'] )        ? $instance['mode']        : 'years';
+        $target_page = isset( $instance['target_page'] ) ? $instance['target_page'] : 'self';
+        $pub_type    = isset( $instance['pub_type'] )    ? $instance['pub_type']    : 'all';
+        $min_pubs    = isset( $instance['min_pubs'] )    ? absint( $instance['min_pubs'] )    : 1;
+        $show_active = isset( $instance['show_active'] ) ? (bool) $instance['show_active']    : true;
+        $order_years = isset( $instance['order_years'] ) ? $instance['order_years'] : 'DESC';
+        $order_tags  = isset( $instance['order_tags'] )  ? $instance['order_tags']  : 'relevance';
+
+        $base_url = ( $target_page === 'self' ) ? get_permalink() : get_permalink( absint( $target_page ) );
+        if ( ! $base_url ) {
+            return;
+        }
+
+        $active_yr   = isset( $_GET['yr'] )   ? absint( $_GET['yr'] )   : 0;
+        $active_tgid = isset( $_GET['tgid'] ) ? absint( $_GET['tgid'] ) : 0;
+
+        echo $args['before_widget'];
+        if ( $title ) {
+            echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+        }
+
+        if ( $mode === 'years' ) {
+            $this->render_years( $base_url, $pub_type, $order_years, $show_active, $active_yr );
+        } else {
+            $this->render_tags( $base_url, $pub_type, $min_pubs, $order_tags, $show_active, $active_tgid );
+        }
+
+        echo $args['after_widget'];
+    }
+
+    /**
+     * Renders the list of publication years as filter links
+     *
+     * @param  string $base_url    Base URL for the filter links
+     * @param  string $pub_type    'all' or a specific publication type slug
+     * @param  string $order       'ASC' or 'DESC'
+     * @param  bool   $show_active Highlight the currently active year
+     * @param  int    $active_yr   Currently active year from the URL (?yr=)
+     */
+    function render_years( $base_url, $pub_type, $order, $show_active, $active_yr ) {
+        global $wpdb;
+
+        $order = ( strtoupper( $order ) === 'ASC' ) ? 'ASC' : 'DESC';
+
+        if ( $pub_type !== 'all' ) {
+            $years = $wpdb->get_col(
+                $wpdb->prepare(
+                    "SELECT DISTINCT DATE_FORMAT(date, '%%Y') AS yr
+                     FROM " . TEACHPRESS_PUB . "
+                     WHERE type = %s AND date != '0000-00-00'
+                     ORDER BY yr $order",
+                    $pub_type
+                )
+            );
+        } else {
+            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+            $years = $wpdb->get_col(
+                "SELECT DISTINCT DATE_FORMAT(date, '%Y') AS yr
+                 FROM " . TEACHPRESS_PUB . "
+                 WHERE date != '0000-00-00'
+                 ORDER BY yr $order"
+            );
+        }
+
+        if ( empty( $years ) ) {
+            TP_HTML::line( '<p>' . esc_html__( 'No publications found.', 'teachpress' ) . '</p>' );
+            return;
+        }
+
+        TP_HTML::line( '<ul class="tp_filter_years">' );
+        foreach ( $years as $year ) {
+            $year      = intval( $year );
+            $link      = esc_url( add_query_arg( 'yr', $year, $base_url ) );
+            $is_active = ( $show_active && $active_yr === $year );
+            $class     = $is_active ? ' class="active"' : '';
+            $aria      = $is_active ? ' aria-current="true"' : '';
+            TP_HTML::line( '<li' . $class . '><a href="' . $link . '"' . $aria . '>' . esc_html( $year ) . '</a></li>' );
+        }
+        TP_HTML::line( '</ul>' );
+    }
+
+    /**
+     * Renders the list of tags as filter links
+     *
+     * The publication count used to sort by relevance and to apply the
+     * $min_pubs threshold respects the $pub_type filter: if a type is
+     * selected, only publications of that type are counted.
+     *
+     * @param  string $base_url    Base URL for the filter links
+     * @param  string $pub_type    'all' or a specific publication type slug
+     * @param  int    $min_pubs    Minimum number of publications required to show a tag
+     * @param  string $order       'relevance' (by count DESC) or 'alpha' (A-Z)
+     * @param  bool   $show_active Highlight the currently active tag
+     * @param  int    $active_tgid Currently active tag ID from the URL (?tgid=)
+     */
+    function render_tags( $base_url, $pub_type, $min_pubs, $order, $show_active, $active_tgid ) {
+        global $wpdb;
+
+        $order_clause = ( $order === 'alpha' ) ? 't.name ASC' : 'pub_count DESC';
+        $min_pubs     = max( 1, absint( $min_pubs ) );
+
+        if ( $pub_type !== 'all' ) {
+            $tags = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT t.tag_id, t.name, COUNT(r.pub_id) AS pub_count
+                     FROM " . TEACHPRESS_TAGS . " t
+                     INNER JOIN " . TEACHPRESS_RELATION . " r ON t.tag_id = r.tag_id
+                     INNER JOIN " . TEACHPRESS_PUB . " p ON r.pub_id = p.pub_id
+                     WHERE p.type = %s
+                     GROUP BY t.tag_id, t.name
+                     HAVING pub_count >= %d
+                     ORDER BY $order_clause",
+                    $pub_type,
+                    $min_pubs
+                )
+            );
+        } else {
+            $tags = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT t.tag_id, t.name, COUNT(r.pub_id) AS pub_count
+                     FROM " . TEACHPRESS_TAGS . " t
+                     INNER JOIN " . TEACHPRESS_RELATION . " r ON t.tag_id = r.tag_id
+                     GROUP BY t.tag_id, t.name
+                     HAVING pub_count >= %d
+                     ORDER BY $order_clause",
+                    $min_pubs
+                )
+            );
+        }
+
+        if ( empty( $tags ) ) {
+            TP_HTML::line( '<p>' . esc_html__( 'No tags found.', 'teachpress' ) . '</p>' );
+            return;
+        }
+
+        TP_HTML::line( '<ul class="tp_filter_tags">' );
+        foreach ( $tags as $tag ) {
+            $link      = esc_url( add_query_arg( 'tgid', intval( $tag->tag_id ), $base_url ) );
+            $is_active = ( $show_active && $active_tgid === intval( $tag->tag_id ) );
+            $class     = $is_active ? ' class="active"' : '';
+            $aria      = $is_active ? ' aria-current="true"' : '';
+            TP_HTML::line( '<li' . $class . '><a href="' . $link . '"' . $aria . '>' . esc_html( stripslashes( $tag->name ) ) . '</a></li>' );
+        }
+        TP_HTML::line( '</ul>' );
+    }
+
+    /**
+     * Update / save widget settings
+     *
+     * @see    WP_Widget::update
+     * @param  array $new_instance Settings just submitted by the user
+     * @param  array $old_instance Previously saved settings
+     * @return array               Sanitised settings to store
+     */
+    function update( $new_instance, $old_instance ) {
+        $instance = array();
+
+        $instance['title'] = sanitize_text_field( $new_instance['title'] );
+
+        $instance['mode'] = in_array( $new_instance['mode'], array( 'years', 'tags' ), true )
+            ? $new_instance['mode']
+            : 'years';
+
+        if ( isset( $new_instance['target_page'] ) && $new_instance['target_page'] === 'self' ) {
+            $instance['target_page'] = 'self';
+        } else {
+            $page_id = absint( isset( $new_instance['target_page_page'] ) ? $new_instance['target_page_page'] : 0 );
+            $instance['target_page'] = ( $page_id > 0 ) ? $page_id : 'self';
+        }
+
+        if ( isset( $new_instance['pub_type'] ) && $new_instance['pub_type'] === 'all' ) {
+            $instance['pub_type'] = 'all';
+        } else {
+            $type_value = sanitize_key( isset( $new_instance['pub_type_value'] ) ? $new_instance['pub_type_value'] : '' );
+            $instance['pub_type'] = ( $type_value !== '' ) ? $type_value : 'all';
+        }
+
+        $instance['min_pubs']    = max( 1, absint( isset( $new_instance['min_pubs'] ) ? $new_instance['min_pubs'] : 1 ) );
+        $instance['show_active'] = ! empty( $new_instance['show_active'] );
+
+        $order_years_raw         = strtoupper( isset( $new_instance['order_years'] ) ? $new_instance['order_years'] : 'DESC' );
+        $instance['order_years'] = in_array( $order_years_raw, array( 'ASC', 'DESC' ), true ) ? $order_years_raw : 'DESC';
+
+        $order_tags_raw         = isset( $new_instance['order_tags'] ) ? $new_instance['order_tags'] : 'relevance';
+        $instance['order_tags'] = in_array( $order_tags_raw, array( 'relevance', 'alpha' ), true ) ? $order_tags_raw : 'relevance';
+
+        return $instance;
+    }
+
+    /**
+     * Widget admin form
+     *
+     * @see    WP_Widget::form
+     * @param  array $instance Currently saved settings
+     */
+    function form( $instance ) {
+        $title       = isset( $instance['title'] )       ? esc_attr( $instance['title'] )    : '';
+        $mode        = isset( $instance['mode'] )        ? $instance['mode']                  : 'years';
+        $target_page = isset( $instance['target_page'] ) ? $instance['target_page']           : 'self';
+        $pub_type    = isset( $instance['pub_type'] )    ? $instance['pub_type']              : 'all';
+        $min_pubs    = isset( $instance['min_pubs'] )    ? absint( $instance['min_pubs'] )    : 1;
+        $show_active = isset( $instance['show_active'] ) ? (bool) $instance['show_active']    : true;
+        $order_years = isset( $instance['order_years'] ) ? $instance['order_years']           : 'DESC';
+        $order_tags  = isset( $instance['order_tags'] )  ? $instance['order_tags']            : 'relevance';
+
+        /* ── Section 1: General ───────────────────────────────────── */
+        TP_HTML::line( '<p><label for="' . $this->get_field_id( 'title' ) . '">' . esc_html__( 'Title', 'teachpress' ) . ': <input class="widefat" id="' . $this->get_field_id( 'title' ) . '" name="' . $this->get_field_name( 'title' ) . '" type="text" value="' . $title . '" /></label></p>' );
+
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Mode', 'teachpress' ) . '</strong><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'mode' ) . '" value="years"' . checked( $mode, 'years', false ) . ' /> ' . esc_html__( 'Years', 'teachpress' ) . '</label>&nbsp;&nbsp;' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'mode' ) . '" value="tags"' . checked( $mode, 'tags', false ) . ' /> ' . esc_html__( 'Tags', 'teachpress' ) . '</label></p>' );
+
+        /* ── Section 2: Target page ───────────────────────────────── */
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Target page', 'teachpress' ) . '</strong><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'target_page' ) . '" value="self"' . checked( $target_page, 'self', false ) . ' /> ' . esc_html__( 'Same page as widget', 'teachpress' ) . '</label></p>' );
+        TP_HTML::line( '<p><label><input type="radio" name="' . $this->get_field_name( 'target_page' ) . '" value="custom"' . checked( ( $target_page !== 'self' ? 'custom' : 'self' ), 'custom', false ) . ' /> ' . esc_html__( 'Choose a page:', 'teachpress' ) . '</label>' );
+
+        $selected_page_id = ( $target_page !== 'self' ) ? absint( $target_page ) : 0;
+        wp_dropdown_pages( array(
+            'name'             => $this->get_field_name( 'target_page' ) . '_page',
+            'id'               => $this->get_field_id( 'target_page' ) . '_page',
+            'selected'         => $selected_page_id,
+            'show_option_none' => esc_html__( '— Select a page —', 'teachpress' ),
+            'class'            => 'widefat',
+        ) );
+        TP_HTML::line( '</p>' );
+
+        /* ── Section 3: Filters ───────────────────────────────────── */
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Publication filter', 'teachpress' ) . '</strong><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'pub_type' ) . '" value="all"' . checked( $pub_type, 'all', false ) . ' /> ' . esc_html__( 'All types', 'teachpress' ) . '</label><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'pub_type' ) . '" value="custom"' . checked( ( $pub_type !== 'all' ? 'custom' : 'all' ), 'custom', false ) . ' /> ' . esc_html__( 'Specific type:', 'teachpress' ) . '</label>' );
+        TP_HTML::line( '<select id="' . $this->get_field_id( 'pub_type_value' ) . '" name="' . $this->get_field_name( 'pub_type_value' ) . '" class="widefat">' );
+            $used_types = TP_Publications::get_used_pubtypes( array( 'output_type' => ARRAY_A ) );
+            foreach ( $used_types as $row ) {
+                $selected = ( $pub_type === $row['type'] ) ? ' selected="selected"' : '';
+                TP_HTML::line( '<option value="' . esc_attr( $row['type'] ) . '"' . $selected . '>' . esc_html( tp_translate_pub_type( $row['type'], 'sin' ) ) . '</option>' );
+            }
+        TP_HTML::line( '</select></p>' );
+
+        TP_HTML::line( '<p><label for="' . $this->get_field_id( 'min_pubs' ) . '">' . esc_html__( 'Minimum publications per tag (tags mode only)', 'teachpress' ) . ': <input class="widefat" id="' . $this->get_field_id( 'min_pubs' ) . '" name="' . $this->get_field_name( 'min_pubs' ) . '" type="number" min="1" value="' . esc_attr( $min_pubs ) . '" /></label></p>' );
+
+        /* ── Section 4: Display ───────────────────────────────────── */
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Display options', 'teachpress' ) . '</strong></p>' );
+
+        TP_HTML::line( '<p><label><input type="checkbox" id="' . $this->get_field_id( 'show_active' ) . '" name="' . $this->get_field_name( 'show_active' ) . '" value="1"' . checked( $show_active, true, false ) . ' /> ' . esc_html__( 'Highlight active filter (CSS class "active" + aria-current)', 'teachpress' ) . '</label></p>' );
+
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Year order', 'teachpress' ) . '</strong><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'order_years' ) . '" value="DESC"' . checked( $order_years, 'DESC', false ) . ' /> ' . esc_html__( 'Newest first', 'teachpress' ) . '</label>&nbsp;&nbsp;' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'order_years' ) . '" value="ASC"' . checked( $order_years, 'ASC', false ) . ' /> ' . esc_html__( 'Oldest first', 'teachpress' ) . '</label></p>' );
+
+        TP_HTML::line( '<p><strong>' . esc_html__( 'Tag order', 'teachpress' ) . '</strong><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'order_tags' ) . '" value="relevance"' . checked( $order_tags, 'relevance', false ) . ' /> ' . esc_html__( 'By relevance (most used first)', 'teachpress' ) . '</label><br />' );
+        TP_HTML::line( '<label><input type="radio" name="' . $this->get_field_name( 'order_tags' ) . '" value="alpha"' . checked( $order_tags, 'alpha', false ) . ' /> ' . esc_html__( 'Alphabetical (A → Z)', 'teachpress' ) . '</label></p>' );
+    }
+}
+
+
+/**
+ * Render callback for the teachPress Filter block (FSE / block editor).
+ *
+ * Delegates entirely to TP_Filter_Widget::widget() so front-end output
+ * is identical whether the widget or the block is used.
+ *
+ * @param  array $attributes Block attributes as saved by the editor
+ * @return string            Rendered HTML
+ * @since  9.0.13
+ */
+function tp_render_filter_block( $attributes ) {
+    $instance = array(
+        'title'       => isset( $attributes['title'] )       ? $attributes['title']               : '',
+        'mode'        => isset( $attributes['mode'] )        ? $attributes['mode']        : 'years',
+        'target_page' => isset( $attributes['target_page'] ) ? $attributes['target_page'] : 'self',
+        'pub_type'    => isset( $attributes['pub_type'] )    ? $attributes['pub_type']    : 'all',
+        'min_pubs'    => isset( $attributes['min_pubs'] )    ? absint( $attributes['min_pubs'] )   : 1,
+        'show_active' => isset( $attributes['show_active'] ) ? (bool) $attributes['show_active']   : true,
+        'order_years' => isset( $attributes['order_years'] ) ? $attributes['order_years'] : 'DESC',
+        'order_tags'  => isset( $attributes['order_tags'] )  ? $attributes['order_tags']  : 'relevance',
+    );
+
+    $widget = new TP_Filter_Widget();
+    $args   = array(
+        'before_widget' => '<div class="widget widget_teachpress_filter">',
+        'after_widget'  => '</div>',
+        'before_title'  => '<h2 class="widget-title">',
+        'after_title'   => '</h2>',
+    );
+
+    ob_start();
+    $widget->widget( $args, $instance );
+    return ob_get_clean();
+}
+
+/**
+ * Registers the teachPress Filter block for FSE / block editor compatibility.
+ *
+ * Hooked to 'init' in teachpress.php.
+ * The editor UI is handled by blocks/filter/index.js (vanilla ES5, no build step).
+ *
+ * @since 9.0.13
+ */
+function tp_register_filter_block() {
+    if ( ! function_exists( 'register_block_type' ) ) {
+        return;
+    }
+
+    wp_register_script(
+        'tp-filter-block',
+        plugins_url( 'js/tp-filter-block.js', TEACHPRESS_GLOBAL_PATH . 'teachpress.php' ),
+        array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-server-side-render', 'wp-i18n' ),
+        get_tp_version(),
+        true
+    );
+
+    $used_types   = TP_Publications::get_used_pubtypes( array( 'output_type' => ARRAY_A ) );
+    $type_options = array( array( 'label' => __( 'All types', 'teachpress' ), 'value' => 'all' ) );
+    foreach ( $used_types as $row ) {
+        $type_options[] = array(
+            'label' => tp_translate_pub_type( $row['type'], 'sin' ),
+            'value' => $row['type'],
+        );
+    }
+    wp_localize_script( 'tp-filter-block', 'tpFilterBlock', array(
+        'pubTypes' => $type_options,
+    ) );
+
+    register_block_type( 'teachpress/filter', array(
+        'editor_script'   => 'tp-filter-block',
+        'render_callback' => 'tp_render_filter_block',
+        'attributes'      => array(
+            'title'       => array( 'type' => 'string',  'default' => '' ),
+            'mode'        => array( 'type' => 'string',  'default' => 'years' ),
+            'target_page' => array( 'type' => 'string',  'default' => 'self' ),
+            'pub_type'    => array( 'type' => 'string',  'default' => 'all' ),
+            'min_pubs'    => array( 'type' => 'integer', 'default' => 1 ),
+            'show_active' => array( 'type' => 'boolean', 'default' => true ),
+            'order_years' => array( 'type' => 'string',  'default' => 'DESC' ),
+            'order_tags'  => array( 'type' => 'string',  'default' => 'relevance' ),
+        ),
+    ) );
+}

--- a/js/tp-filter-block.js
+++ b/js/tp-filter-block.js
@@ -1,0 +1,119 @@
+/**
+ * teachPress Filter block – editor registration
+ *
+ * Vanilla ES5, no build step required.
+ * Works with WordPress 5.8+ (wp-server-side-render, wp-block-editor).
+ * Publication types are passed from PHP via wp_localize_script (tpFilterBlock.pubTypes).
+ *
+ * @package teachpress\js
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GPLv2 or later
+ * @since   9.0.13
+ */
+( function () {
+    'use strict';
+
+    var registerBlockType = wp.blocks.registerBlockType;
+    var el                = wp.element.createElement;
+    var __                = wp.i18n.__;
+    var InspectorControls = wp.blockEditor.InspectorControls;
+    var PanelBody         = wp.components.PanelBody;
+    var TextControl       = wp.components.TextControl;
+    var SelectControl     = wp.components.SelectControl;
+    var ToggleControl     = wp.components.ToggleControl;
+    var RadioControl      = wp.components.RadioControl;
+    var ServerSideRender  = wp.serverSideRender;
+
+    // Publication types passed from PHP via wp_localize_script.
+    // Falls back to a single "All types" option if data is unavailable.
+    var pubTypeOptions = ( window.tpFilterBlock && window.tpFilterBlock.pubTypes )
+        ? window.tpFilterBlock.pubTypes
+        : [ { label: __( 'All types', 'teachpress' ), value: 'all' } ];
+
+    registerBlockType( 'teachpress/filter', {
+        title:    __( 'teachPress Filter', 'teachpress' ),
+        icon:     'filter',
+        category: 'widgets',
+        supports: { html: false },
+
+        edit: function ( props ) {
+            var attr    = props.attributes;
+            var setAttr = props.setAttributes;
+
+            return [
+                el( InspectorControls, { key: 'controls' },
+
+                    el( PanelBody, { title: __( 'General', 'teachpress' ), initialOpen: true },
+                        el( TextControl, {
+                            label:    __( 'Title', 'teachpress' ),
+                            value:    attr.title,
+                            onChange: function ( v ) { setAttr( { title: v } ); }
+                        } ),
+                        el( RadioControl, {
+                            label:    __( 'Mode', 'teachpress' ),
+                            selected: attr.mode,
+                            options: [
+                                { label: __( 'Years', 'teachpress' ), value: 'years' },
+                                { label: __( 'Tags',  'teachpress' ), value: 'tags'  }
+                            ],
+                            onChange: function ( v ) { setAttr( { mode: v } ); }
+                        } )
+                    ),
+
+                    el( PanelBody, { title: __( 'Publication filter', 'teachpress' ), initialOpen: false },
+                        el( SelectControl, {
+                            label:    __( 'Publication type', 'teachpress' ),
+                            value:    attr.pub_type,
+                            options:  pubTypeOptions,
+                            onChange: function ( v ) { setAttr( { pub_type: v } ); }
+                        } ),
+                        attr.mode === 'tags' && el( TextControl, {
+                            label:    __( 'Minimum publications per tag', 'teachpress' ),
+                            type:     'number',
+                            value:    String( attr.min_pubs ),
+                            min:      1,
+                            onChange: function ( v ) { setAttr( { min_pubs: Math.max( 1, parseInt( v, 10 ) || 1 ) } ); }
+                        } )
+                    ),
+
+                    el( PanelBody, { title: __( 'Display options', 'teachpress' ), initialOpen: false },
+                        el( ToggleControl, {
+                            label:    __( 'Highlight active filter', 'teachpress' ),
+                            help:     __( 'Adds CSS class "active" and aria-current to the active item', 'teachpress' ),
+                            checked:  attr.show_active,
+                            onChange: function ( v ) { setAttr( { show_active: v } ); }
+                        } ),
+                        el( RadioControl, {
+                            label:    __( 'Year order', 'teachpress' ),
+                            selected: attr.order_years,
+                            options: [
+                                { label: __( 'Newest first', 'teachpress' ), value: 'DESC' },
+                                { label: __( 'Oldest first', 'teachpress' ), value: 'ASC'  }
+                            ],
+                            onChange: function ( v ) { setAttr( { order_years: v } ); }
+                        } ),
+                        el( RadioControl, {
+                            label:    __( 'Tag order', 'teachpress' ),
+                            selected: attr.order_tags,
+                            options: [
+                                { label: __( 'By relevance (most used first)', 'teachpress' ), value: 'relevance' },
+                                { label: __( 'Alphabetical (A → Z)',           'teachpress' ), value: 'alpha'     }
+                            ],
+                            onChange: function ( v ) { setAttr( { order_tags: v } ); }
+                        } )
+                    )
+                ),
+
+                el( ServerSideRender, {
+                    key:        'preview',
+                    block:      'teachpress/filter',
+                    attributes: attr
+                } )
+            ];
+        },
+
+        save: function () {
+            return null; // entirely server-side rendered
+        }
+    } );
+
+} )();

--- a/styles/teachpress_front.css
+++ b/styles/teachpress_front.css
@@ -116,3 +116,13 @@ li.tp_cite_entry {font-size:0.9rem;}
 .tp_lvs_name {font-size:14px;}
 td.tp_lvs_container {margin:5px; border-bottom:1px solid silver; border-right:1px solid silver; padding:7px 5px 7px 5px;}
 .tp_lvs_comments {padding-top:5px; margin:0; min-height:17px;}
+
+/****************************/
+/* teachPress Filter widget */
+/****************************/
+.tp_filter_years,
+.tp_filter_tags { list-style: none; padding: 0; margin: 0; }
+.tp_filter_years li,
+.tp_filter_tags li { padding: 2px 0; }
+.tp_filter_years li.active a,
+.tp_filter_tags li.active a { font-weight: bold; }

--- a/teachpress.php
+++ b/teachpress.php
@@ -74,6 +74,7 @@ include_once('core/publications/default-publication-types.php');
 include_once('core/publications/default-awards.php');
 include_once('core/publications/templates.php');
 include_once('core/publications/class-books-widget.php');
+include_once('core/publications/class-filter-widget.php');
 
 // Admin menus
 if ( is_admin() ) {
@@ -564,3 +565,5 @@ add_shortcode('tplinks', 'tp_links_shortcode');
 add_shortcode('tpsearch', 'tp_search_shortcode');
 add_shortcode('tpcite', 'tp_cite_shortcode');
 add_shortcode('tpref','tp_ref_shortcode');
+add_action('init', 'tp_register_filter_block');
+add_action('widgets_init', function(){ register_widget( 'TP_Filter_Widget' ); });


### PR DESCRIPTION
## Summary

This PR introduces `TP_Filter_Widget`, a configurable sidebar widget 
that renders a list of publication years or tags as clickable filter 
links, compatible with the [tplist], [tpcloud] and [tpsearch] shortcodes 
(URL parameters ?yr= and ?tgid=).

## Widget settings

- **Mode:** years or tags
- **Target page:** same page as the widget, or any WordPress page
- **Publication type filter:** only types actually present in the 
  database are shown in the dropdown
- **Minimum publications per tag** (tags mode): hides tags below 
  the threshold, respecting the selected publication type
- **Highlight active filter:** adds CSS class `active` and 
  `aria-current="true"` to the active item
- **Year order:** newest first (DESC) or oldest first (ASC)
- **Tag order:** by relevance (publication count DESC) or alphabetical

## FSE / block editor compatibility

The widget is also registered as a native Gutenberg block 
(`teachpress/filter`) via `register_block_type()` with a PHP render 
callback, so it works in Full Site Editing themes without any changes 
to the existing widget code.

The block editor UI (`js/tp-filter-block.js`) is written in vanilla 
ES5 — no build step required. Publication types available in the 
dropdown are passed dynamically from PHP via `wp_localize_script`, 
so only types present in the database are shown.

## Files changed

- `core/publications/class-filter-widget.php` — new
- `js/tp-filter-block.js` — new
- `teachpress.php` — include + two hook registrations
- `styles/teachpress_front.css` — base CSS for the widget lists